### PR TITLE
Adds safe check for contract falsiness

### DIFF
--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -66,6 +66,16 @@ def _kwargs_from_call(param_names: List[str], kwdefaults: Dict[str, Any], args: 
     return mapping
 
 
+def safe_not(check, contract):
+    """ Not that catches numpy boolean insanity """
+    try:
+        return not check
+    except Exception as exc:
+        raise ViolationError(
+            f"{contract.location} {contract.description} failed boolean check"
+        ) from exc
+
+
 def _assert_precondition(contract: Contract, resolved_kwargs: Mapping[str, Any]) -> None:
     """
     Assert that the contract holds as a precondition.
@@ -88,7 +98,7 @@ def _assert_precondition(contract: Contract, resolved_kwargs: Mapping[str, Any])
 
     check = contract.condition(**condition_kwargs)
 
-    if not check:
+    if safe_not(check, contract):
         if contract.error is not None and (inspect.ismethod(contract.error) or inspect.isfunction(contract.error)):
             assert contract.error_arg_set is not None, "Expected error_arg_set non-None if contract.error a function."
             assert contract.error_args is not None, "Expected error_args non-None if contract.error a function."
@@ -127,7 +137,7 @@ def _assert_invariant(contract: Contract, instance: Any) -> None:
     else:
         check = contract.condition()
 
-    if not check:
+    if safe_not(check, contract):
         if contract.error is not None and (inspect.ismethod(contract.error) or inspect.isfunction(contract.error)):
             assert contract.error_arg_set is not None, "Expected error_arg_set non-None if contract.error a function."
             assert contract.error_args is not None, "Expected error_args non-None if contract.error a function."
@@ -199,7 +209,7 @@ def _assert_postcondition(contract: Contract, resolved_kwargs: Mapping[str, Any]
 
     check = contract.condition(**condition_kwargs)
 
-    if not check:
+    if safe_not(check, contract):
         if contract.error is not None and (inspect.ismethod(contract.error) or inspect.isfunction(contract.error)):
             assert contract.error_arg_set is not None, "Expected error_arg_set non-None if contract.error a function."
             assert contract.error_args is not None, "Expected error_args non-None if contract.error a function."

--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -85,7 +85,7 @@ def _assert_precondition(contract: Contract, resolved_kwargs: Mapping[str, Any])
     :return:
     """
     # Check that all arguments to the condition function have been set.
-    missing_args = [arg_name for arg_name in contract.condition_args if arg_name not in resolved_kwargs]
+    missing_args = [arg_name for arg_name in contract.mandatory_args if arg_name not in resolved_kwargs]
     if missing_args:
         raise TypeError(
             ("The argument(s) of the precondition have not been set: {}. "
@@ -196,7 +196,7 @@ def _assert_postcondition(contract: Contract, resolved_kwargs: Mapping[str, Any]
         "Expected 'result' to be set in the resolved keyword arguments of a postcondition."
 
     # Check that all arguments to the condition function have been set.
-    missing_args = [arg_name for arg_name in contract.condition_args if arg_name not in resolved_kwargs]
+    missing_args = [arg_name for arg_name in contract.mandatory_args if arg_name not in resolved_kwargs]
     if missing_args:
         raise TypeError(
             ("The argument(s) of the postcondition have not been set: {}. "
@@ -276,6 +276,7 @@ def decorate_with_checker(func: CallableT) -> CallableT:
 
     # Determine the default argument values.
     kwdefaults = dict()  # type: Dict[str, Any]
+
 
     # Add to the defaults all the values that are needed by the contracts.
     for param in sign.parameters.values():

--- a/icontract/_decorators.py
+++ b/icontract/_decorators.py
@@ -53,7 +53,13 @@ class require:  # pylint: disable=invalid-name
         if not enabled:
             return
 
-        self._contract = Contract(condition=condition, description=description, a_repr=a_repr, error=error)
+        location = None  # type: Optional[str]
+        tb_stack = traceback.extract_stack(limit=2)[:1]
+        if len(tb_stack) > 0:
+            frame = tb_stack[0]
+            location = 'File {}, line {} in {}'.format(frame.filename, frame.lineno, frame.name)
+
+        self._contract = Contract(condition=condition, description=description, a_repr=a_repr, error=error, location=location)
 
     def __call__(self, func: CallableT) -> CallableT:
         """
@@ -214,7 +220,13 @@ class ensure:  # pylint: disable=invalid-name
         if not enabled:
             return
 
-        self._contract = Contract(condition=condition, description=description, a_repr=a_repr, error=error)
+        location = None  # type: Optional[str]
+        tb_stack = traceback.extract_stack(limit=2)[:1]
+        if len(tb_stack) > 0:
+            frame = tb_stack[0]
+            location = 'File {}, line {} in {}'.format(frame.filename, frame.lineno, frame.name)
+
+        self._contract = Contract(condition=condition, description=description, a_repr=a_repr, error=error, location=location)
 
     def __call__(self, func: CallableT) -> CallableT:
         """

--- a/icontract/_types.py
+++ b/icontract/_types.py
@@ -40,6 +40,11 @@ class Contract:
         self.condition_args = list(inspect.signature(condition).parameters.keys())  # type: List[str]
         self.condition_arg_set = set(self.condition_args)  # type: Set[str]
 
+        self.mandatory_args = [
+            name for name, param in inspect.signature(condition).parameters.items()
+            if param.default == inspect._empty
+        ]
+
         self.description = description
         self._a_repr = a_repr
 


### PR DESCRIPTION
Catches common numpy pattern where if not x fails when
x is a vector type.  Adds contract location of require/ensure
decorators