### PR TITLE
fixed performance regression due to state

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -787,9 +787,9 @@ Benchmarking invariant at __init__:
 =========================  ============  ==============  =======================
 Case                         Total time    Time per run    Relative time per run
 =========================  ============  ==============  =======================
-`ClassWithIcontract`             2.13 s         2.13 μs                     304%
-`ClassWithDpcontracts`           0.70 s         0.70 μs                     100%
-`ClassWithInlineContract`        0.45 s         0.45 μs                      64%
+`ClassWithIcontract`             2.14 s         2.14 μs                     314%
+`ClassWithDpcontracts`           0.68 s         0.68 μs                     100%
+`ClassWithInlineContract`        0.42 s         0.42 μs                      62%
 =========================  ============  ==============  =======================
 
 Benchmarking invariant at a function:
@@ -797,9 +797,9 @@ Benchmarking invariant at a function:
 =========================  ============  ==============  =======================
 Case                         Total time    Time per run    Relative time per run
 =========================  ============  ==============  =======================
-`ClassWithIcontract`             2.87 s         2.87 μs                     417%
-`ClassWithDpcontracts`           0.69 s         0.69 μs                     100%
-`ClassWithInlineContract`        0.36 s         0.36 μs                      52%
+`ClassWithIcontract`             2.91 s         2.91 μs                     445%
+`ClassWithDpcontracts`           0.65 s         0.65 μs                     100%
+`ClassWithInlineContract`        0.33 s         0.33 μs                      51%
 =========================  ============  ==============  =======================
 
 Benchmarking precondition:
@@ -807,9 +807,9 @@ Benchmarking precondition:
 ===============================  ============  ==============  =======================
 Case                               Total time    Time per run    Relative time per run
 ===============================  ============  ==============  =======================
-`function_with_icontract`              0.03 s         3.23 μs                       1%
-`function_with_dpcontracts`            2.77 s       277.30 μs                     100%
-`function_with_inline_contract`        0.00 s         0.15 μs                       0%
+`function_with_icontract`              0.03 s         3.46 μs                       1%
+`function_with_dpcontracts`            2.85 s       285.11 μs                     100%
+`function_with_inline_contract`        0.00 s         0.14 μs                       0%
 ===============================  ============  ==============  =======================
 
 Benchmarking postcondition:
@@ -817,9 +817,9 @@ Benchmarking postcondition:
 ===============================  ============  ==============  =======================
 Case                               Total time    Time per run    Relative time per run
 ===============================  ============  ==============  =======================
-`function_with_icontract`              0.04 s         4.16 μs                       1%
-`function_with_dpcontracts`            2.79 s       278.62 μs                     100%
-`function_with_inline_contract`        0.00 s         0.15 μs                       0%
+`function_with_icontract`              0.03 s         3.38 μs                       1%
+`function_with_dpcontracts`            2.84 s       283.59 μs                     100%
+`function_with_inline_contract`        0.00 s         0.14 μs                       0%
 ===============================  ============  ==============  =======================
 
 

--- a/README.rst
+++ b/README.rst
@@ -778,19 +778,28 @@ The following scripts were run:
 * `benchmarks/against_dpcontracts/compare_postcondition.py <https://github.com/Parquery/icontract/tree/master/benchmarks/against_dpcontracts/compare_postcondition.py>`_
 
 The benchmarks were executed on Intel(R) Core(TM) i7-4700MQ CPU @ 2.40GHz.
-We used icontract 2.3.2 and dpcontracts 0.6.0.
+We used icontract 2.3.2.post1 and dpcontracts 0.6.0.
 
 The following tables summarize the results.
 
-Benchmarking invariant:
+Benchmarking invariant at __init__:
 
 =========================  ============  ==============  =======================
 Case                         Total time    Time per run    Relative time per run
 =========================  ============  ==============  =======================
-`ClassWithIcontract`             2.16 s         2.16 μs                     313%
+`ClassWithIcontract`             2.13 s         2.13 μs                     304%
+`ClassWithDpcontracts`           0.70 s         0.70 μs                     100%
+`ClassWithInlineContract`        0.45 s         0.45 μs                      64%
+=========================  ============  ==============  =======================
+
+Benchmarking invariant at a function:
+
+=========================  ============  ==============  =======================
+Case                         Total time    Time per run    Relative time per run
+=========================  ============  ==============  =======================
+`ClassWithIcontract`             2.87 s         2.87 μs                     417%
 `ClassWithDpcontracts`           0.69 s         0.69 μs                     100%
-`ClassWithInlineContract`        0.42 s         0.42 μs                      61%
-`ClassWithoutContracts`          0.36 s         0.36 μs                      51%
+`ClassWithInlineContract`        0.36 s         0.36 μs                      52%
 =========================  ============  ==============  =======================
 
 Benchmarking precondition:
@@ -798,10 +807,9 @@ Benchmarking precondition:
 ===============================  ============  ==============  =======================
 Case                               Total time    Time per run    Relative time per run
 ===============================  ============  ==============  =======================
-`function_with_icontract`              0.03 s         3.22 μs                       1%
-`function_with_dpcontracts`            2.92 s       292.30 μs                     100%
+`function_with_icontract`              0.03 s         3.23 μs                       1%
+`function_with_dpcontracts`            2.77 s       277.30 μs                     100%
 `function_with_inline_contract`        0.00 s         0.15 μs                       0%
-`function_without_contracts`           0.00 s         0.12 μs                       0%
 ===============================  ============  ==============  =======================
 
 Benchmarking postcondition:
@@ -809,10 +817,9 @@ Benchmarking postcondition:
 ===============================  ============  ==============  =======================
 Case                               Total time    Time per run    Relative time per run
 ===============================  ============  ==============  =======================
-`function_with_icontract`              0.04 s         4.46 μs                       2%
-`function_with_dpcontracts`            2.92 s       292.21 μs                     100%
-`function_with_inline_contract`        0.00 s         0.16 μs                       0%
-`function_without_contracts`           0.00 s         0.11 μs                       0%
+`function_with_icontract`              0.04 s         4.16 μs                       1%
+`function_with_dpcontracts`            2.79 s       278.62 μs                     100%
+`function_with_inline_contract`        0.00 s         0.15 μs                       0%
 ===============================  ============  ==============  =======================
 
 

--- a/README.rst
+++ b/README.rst
@@ -759,168 +759,76 @@ worked fine on our code base.
 
 Benchmarks
 ==========
-We evaluated the computational costs incurred by using icontract in a couple of experiments. There are basically two
-types of costs caused by icontract: 1) extra parsing performed when you import the module regardless whether conditions
-are switched on or off and 2) run-time cost of verifying the contract.
+We run benchmarks against dpcontracts as part of our continuous integration.
 
-We assumed in all the experiments that the contract breaches are exceptionally seldom and thus need not to be analyzed.
-If you are interested in these additional expereminets, please do let us know and create an issue on the github page.
+The bodies of the constructors and functions were intentionally left simple so that you can
+better estimate **overhead** of the contracts in absolute terms rather than relative.
+This means that the code without contracts will run extremely fast (nanoseconds) in the benchmarks
+which might make the contracts seem sluggish. However, the methods in the real world usually run
+in the order of microseconds and milliseconds, not nanoseconds. Hence, as long as the overhead
+of the contract is in the order of microseconds, it is practically acceptable.
 
-The source code of the benchmarks is available in
-`this directory <https://github.com/Parquery/icontract/tree/master/benchmarks>`_.
-All experiments were performed with Python 3.5.2+ on Intel(R) Core(TM) i7-4700MQ CPU @ 2.40GHz with 8 cores and
-4 GB RAM.
-
-We execute a short timeit snippet to bring the following measurements into context:
-
-.. code-block:: bash
-
-    python3 -m timeit -s 'import math' 'math.sqrt(1984.1234)'
-    10000000 loops, best of 3: 0.0679 usec per loop
-
-Import Cost
------------
-**Pre and post-conditions.**
-We generated a module with 100 functions. For each of these functions, we introduced a variable number of conditions and
-stop-watched how long it takes to import the module over 10 runs. Finally, we compared the import time of the module
-with contracts against the same module without any contracts in the code.
-
-The overhead is computed as the time difference between the total import time compared to the total import time of the
-module without the contracts.
-
-+-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
-| Number of conditions per function | Total import time [milliseconds] | Overhead [milliseconds] | Overhead per condition and function [milliseconds] |
-+===================================+==================================+=========================+====================================================+
-| None                              |                   795.59 ± 10.47 |                     N/A |                                                N/A |
-+-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
-| 1                                 |                   919.53 ± 61.22 |                  123.93 |                                               1.24 |
-+-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
-| 5                                 |                  1075.81 ± 59.87 |                  280.22 |                                               0.56 |
-+-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
-| 10                                |                  1290.22 ± 90.04 |                  494.63 |                                               0.49 |
-+-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
-| 1 disabled                        |                   833.60 ± 32.07 |                   37.41 |                                               0.37 |
-+-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
-| 5 disabled                        |                   851.31 ± 66.93 |                   55.72 |                                               0.11 |
-+-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
-| 10 disabled                       |                  897.90 ± 143.02 |                  101.41 |                                               0.10 |
-+-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
-
-As we can see in the table above, the overhead per condition is quite minimal (1.24 milliseconds in case of a single
-enabled contract). The overhead decreases as you add more conditions since the icontract has already initialized all the
-necessary fields in the function objects.
-
-When you disable the conditions, there is much less overhead (only 0.37 milliseconds, and decreasing). Since icontract
-returns immediately when the condition is disabled by implementation, we assume that the overhead coming from disabled
-conditions is mainly caused by Python interpreter parsing the code.
+.. Becnhmark report from precommit.py starts.
 
 
-**Invariants**. Analogously, to measure the overhead of the invariants, we generated a module with 100 classes.
-We varied the number of invariant conditions per class and measure the import time over 10 runs. The results
-are presented in the following table.
+The following scripts were run:
 
-+--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
-| Number of conditions per class | Total import time [milliseconds] | Overhead [milliseconds] | Overhead per condition and class [milliseconds] |
-+================================+==================================+=========================+=================================================+
-| None                           |                   843.61 ± 28.21 |                     N/A |                                             N/A |
-+--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
-| 1                              |                  3409.71 ± 95.78 |                  2566.1 |                                           25.66 |
-+--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
-| 5                              |                 4005.93 ± 131.97 |                 3162.32 |                                            6.32 |
-+--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
-| 10                             |                 4801.82 ± 157.56 |                 3958.21 |                                            3.96 |
-+--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
-| 1 disabled                     |                   885.88 ± 44.24 |                   42.27 |                                            0.42 |
-+--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
-| 5 disabled                     |                  912.53 ± 101.91 |                   68.92 |                                            0.14 |
-+--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
-| 10 disabled                    |                  963.77 ± 161.76 |                  120.16 |                                            0.12 |
-+--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+* `benchmarks/against_dpcontracts/compare_invariant.py <https://github.com/Parquery/icontract/tree/master/benchmarks/against_dpcontracts/compare_invariant.py>`_
+* `benchmarks/against_dpcontracts/compare_precondition.py <https://github.com/Parquery/icontract/tree/master/benchmarks/against_dpcontracts/compare_precondition.py>`_
+* `benchmarks/against_dpcontracts/compare_postcondition.py <https://github.com/Parquery/icontract/tree/master/benchmarks/against_dpcontracts/compare_postcondition.py>`_
 
-Similar to pre and post-conditions, there is decreasing cost per condition as number of conditions increases since the
-icontract has all set up the fields in the class metadata. However, invariants are much more costly compared to pre and
-postconditions and their overhead should be considered if import time needs to be kept minimal.
+The benchmarks were executed on Intel(R) Core(TM) i7-4700MQ CPU @ 2.40GHz.
+We used icontract 2.3.2 and dpcontracts 0.6.0.
 
-The overhead of the disabled invariants is attributed to the overhead of parsing the source file as icontract
-immediately returns from disabled invariants by implementation.
+The following tables summarize the results.
 
-Run-time Cost
--------------
-We constructed four modules around a function which computes a square root. We used ``timeit`` module to measure the
-performance. Each module was imported as part of the setup.
+Benchmarking invariant:
 
-**No precondition**. This module does not check any preconditions and serves as a baseline.
+=========================  ============  ==============  =======================
+Case                         Total time    Time per run    Relative time per run
+=========================  ============  ==============  =======================
+`ClassWithIcontract`             2.16 s         2.16 μs                     313%
+`ClassWithDpcontracts`           0.69 s         0.69 μs                     100%
+`ClassWithInlineContract`        0.42 s         0.42 μs                      61%
+`ClassWithoutContracts`          0.36 s         0.36 μs                      51%
+=========================  ============  ==============  =======================
 
-.. code-block: python
+Benchmarking precondition:
 
-    import math
-    def my_sqrt(x: float) -> float:
-        return math.sqrt(x)
+===============================  ============  ==============  =======================
+Case                               Total time    Time per run    Relative time per run
+===============================  ============  ==============  =======================
+`function_with_icontract`              0.03 s         3.22 μs                       1%
+`function_with_dpcontracts`            2.92 s       292.30 μs                     100%
+`function_with_inline_contract`        0.00 s         0.15 μs                       0%
+`function_without_contracts`           0.00 s         0.12 μs                       0%
+===============================  ============  ==============  =======================
 
-**Pre-condition as assert**. We check pre-conditions by an assert statement.
+Benchmarking postcondition:
 
-.. code-block:: python
+===============================  ============  ==============  =======================
+Case                               Total time    Time per run    Relative time per run
+===============================  ============  ==============  =======================
+`function_with_icontract`              0.04 s         4.46 μs                       2%
+`function_with_dpcontracts`            2.92 s       292.21 μs                     100%
+`function_with_inline_contract`        0.00 s         0.16 μs                       0%
+`function_without_contracts`           0.00 s         0.11 μs                       0%
+===============================  ============  ==============  =======================
 
-    def my_sqrt(x: float) -> float:
-        assert x >= 0
-        return math.sqrt(x)
 
-**Pre-condition as separate function**. To mimick a more complex pre-condition, we encapsulate the assert in a separate
-function.
 
-.. code-block:: python
+.. Benchmark report from precommit.py ends.
 
-    import math
+We also ran a much more extensive battery of benchmarks on icontract 2.0.7. Unfortunately,
+it would cost us too much effort to integrate the results in the continous integration.
+The report is available at:
+`benchmarks/benchmark_2.0.7.rst <https://github.com/Parquery/icontract/tree/master/benchmarks/benchmark_2.0.7.rst>`_.
 
-    def check_non_negative(x: float) -> None:
-        assert x >= 0
-
-    def my_sqrt(x: float) -> float:
-        check_non_negative(x)
-        return math.sqrt(x)
-
-**Pre-condition with icontract**. Finally, we compare against a module that uses icontract.
-
-.. code-block:: python
-
-    import math
-    import icontract
-
-    @icontract.require(lambda x: x >= 0)
-    def my_sqrt(x: float) -> float:
-        return math.sqrt(x)
-
-**Pre-condition with icontract, disabled**. We also perform a redundant check to verify that a disabled condition
-does not incur any run-time cost.
-
-The following table sumarizes the timeit results (10000000 loops, best of 3). The run time of the baseline is computed
-as:
-
-.. code-block: bash
-
-    $ python3 -m timeit -s 'import my_sqrt' 'my_sqrt.my_sqrt(1984.1234)'
-
-The run time of the other functions is computed analogously.
-
-+---------------------+-------------------------+
-| Precondition        | Run time [microseconds] |
-+=====================+=========================+
-| None                |                   0.168 |
-+---------------------+-------------------------+
-| As assert           |                   0.203 |
-+---------------------+-------------------------+
-| As function         |                   0.274 |
-+---------------------+-------------------------+
-| icontract           |                    2.78 |
-+---------------------+-------------------------+
-| icontract, disabled |                   0.165 |
-+---------------------+-------------------------+
-
-The overhead of icontract is substantial. While this may be prohibitive for points where computational efficiency is
-more important than correctness, mind that the overhead is still in order of microseconds. In most practical scenarios,
-where a function is more complex and takes longer than a few microseconds to execute, such a tiny overhead is
-justified by the gains in correctness, development and maintenance time.
-
+The scripts are available at:
+`benchmarks/import_cost/ <https://github.com/Parquery/icontract/tree/master/benchmarks/import_cost>`_
+and
+`benchmarks/runtime_cost/ <https://github.com/Parquery/icontract/tree/master/benchmarks/runtime_cost>`_.
+Please re-run the scripts manually to obtain the results with the latest icontract version.
 
 Installation
 ============

--- a/benchmarks/against_dpcontracts/compare_invariant.py
+++ b/benchmarks/against_dpcontracts/compare_invariant.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+"""
+Benchmark icontract against dpcontracts and no contracts.
+
+The benchmark was supplied by: https://github.com/Parquery/icontract/issues/142
+"""
+from typing import List
+
+import tabulate
+
+import icontract
+import dpcontracts
+
+
+@icontract.invariant(lambda self: len(self.parts) > 0)
+class ClassWithIcontract:
+    def __init__(self, identifier: str) -> None:
+        self.parts = identifier.split(".")
+
+
+@dpcontracts.invariant("some dummy invariant", lambda self: len(self.parts) > 0)
+class ClassWithDpcontracts:
+    def __init__(self, identifier: str) -> None:
+        self.parts = identifier.split(".")
+
+
+class ClassWithInlineContract:
+    def __init__(self, identifier: str) -> None:
+        self.parts = identifier.split(".")
+        assert len(self.parts) > 0
+
+
+class ClassWithoutContracts:
+    def __init__(self, identifier: str) -> None:
+        self.parts = identifier.split(".")
+
+
+if __name__ == "__main__":
+    import timeit
+
+    # dpcontracts change __name__ attribute of the class, so we can not use
+    # ClassWithDpcontractsInvariant.__name__ for a more maintainable list.
+    clses = [
+        'ClassWithIcontract',
+        'ClassWithDpcontracts',
+        'ClassWithInlineContract',
+        'ClassWithoutContracts'
+    ]
+
+    durations = [0.0] * len(clses)
+
+    number = 1 * 1000 * 1000
+
+    for i, cls in enumerate(clses):
+        duration = timeit.timeit(
+            "{}('X.Y')".format(cls),
+            setup="from __main__ import {}".format(cls),
+            number=number)
+        durations[i] = duration
+
+    print("Benchmarking invariant:\n")
+    table = []  # type: List[List[str]]
+
+    for cls, duration in zip(clses, durations):
+        # yapf: disable
+        table.append([
+            '`{}`'.format(cls),
+            '{:.2f} s'.format(duration),
+            '{:.2f} μs'.format(duration * 1000 * 1000 / number),
+            '{:.0f}%'.format(duration * 100 / durations[1])
+        ])
+        # yapf: enable
+
+    # yapf: disable
+    table_str = tabulate.tabulate(
+        table,
+        headers=['Case', 'Total time', 'Time per run', 'Relative time per run'],
+        colalign=('left', 'right', 'right', 'right'),
+        tablefmt='rst')
+    # yapf: enable
+
+    print(table_str)

--- a/benchmarks/against_dpcontracts/compare_invariant.py
+++ b/benchmarks/against_dpcontracts/compare_invariant.py
@@ -5,12 +5,13 @@ Benchmark icontract against dpcontracts and no contracts.
 
 The benchmark was supplied by: https://github.com/Parquery/icontract/issues/142
 """
+import timeit
 from typing import List
 
+import dpcontracts
 import tabulate
 
 import icontract
-import dpcontracts
 
 
 @icontract.invariant(lambda self: len(self.parts) > 0)
@@ -18,11 +19,17 @@ class ClassWithIcontract:
     def __init__(self, identifier: str) -> None:
         self.parts = identifier.split(".")
 
+    def some_func(self) -> str:
+        return '.'.join(self.parts)
+
 
 @dpcontracts.invariant("some dummy invariant", lambda self: len(self.parts) > 0)
 class ClassWithDpcontracts:
     def __init__(self, identifier: str) -> None:
         self.parts = identifier.split(".")
+
+    def some_func(self) -> str:
+        return '.'.join(self.parts)
 
 
 class ClassWithInlineContract:
@@ -30,24 +37,23 @@ class ClassWithInlineContract:
         self.parts = identifier.split(".")
         assert len(self.parts) > 0
 
+    def some_func(self) -> str:
+        assert len(self.parts) > 0
+        result = '.'.join(self.parts)
+        assert len(self.parts) > 0
+        return result
 
-class ClassWithoutContracts:
-    def __init__(self, identifier: str) -> None:
-        self.parts = identifier.split(".")
+
+# dpcontracts change __name__ attribute of the class, so we can not use
+# ClassWithDpcontractsInvariant.__name__ for a more maintainable list.
+clses = [
+    'ClassWithIcontract',
+    'ClassWithDpcontracts',
+    'ClassWithInlineContract',
+]
 
 
-if __name__ == "__main__":
-    import timeit
-
-    # dpcontracts change __name__ attribute of the class, so we can not use
-    # ClassWithDpcontractsInvariant.__name__ for a more maintainable list.
-    clses = [
-        'ClassWithIcontract',
-        'ClassWithDpcontracts',
-        'ClassWithInlineContract',
-        'ClassWithoutContracts'
-    ]
-
+def measure_invariant_at_init() -> None:
     durations = [0.0] * len(clses)
 
     number = 1 * 1000 * 1000
@@ -59,7 +65,7 @@ if __name__ == "__main__":
             number=number)
         durations[i] = duration
 
-    print("Benchmarking invariant:\n")
+    print("Benchmarking invariant at __init__:\n")
     table = []  # type: List[List[str]]
 
     for cls, duration in zip(clses, durations):
@@ -81,3 +87,45 @@ if __name__ == "__main__":
     # yapf: enable
 
     print(table_str)
+
+
+def measure_invariant_at_function() -> None:
+    durations = [0.0] * len(clses)
+
+    number = 1 * 1000 * 1000
+
+    for i, cls in enumerate(clses):
+        duration = timeit.timeit(
+            "a.some_func()",
+            setup="from __main__ import {0}; a = {0}('X.Y')".format(cls),
+            number=number)
+        durations[i] = duration
+
+    print("Benchmarking invariant at a function:\n")
+    table = []  # type: List[List[str]]
+
+    for cls, duration in zip(clses, durations):
+        # yapf: disable
+        table.append([
+            '`{}`'.format(cls),
+            '{:.2f} s'.format(duration),
+            '{:.2f} μs'.format(duration * 1000 * 1000 / number),
+            '{:.0f}%'.format(duration * 100 / durations[1])
+        ])
+        # yapf: enable
+
+    # yapf: disable
+    table_str = tabulate.tabulate(
+        table,
+        headers=['Case', 'Total time', 'Time per run', 'Relative time per run'],
+        colalign=('left', 'right', 'right', 'right'),
+        tablefmt='rst')
+    # yapf: enable
+
+    print(table_str)
+
+
+if __name__ == "__main__":
+    measure_invariant_at_init()
+    print()
+    measure_invariant_at_function()

--- a/benchmarks/against_dpcontracts/compare_postcondition.py
+++ b/benchmarks/against_dpcontracts/compare_postcondition.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+"""
+Benchmark icontract against dpcontracts and no contracts.
+
+The benchmark was supplied by: https://github.com/Parquery/icontract/issues/142
+"""
+import math
+import timeit
+from typing import List
+
+import tabulate
+
+import icontract
+import dpcontracts
+
+
+@icontract.ensure(lambda result: result > 0)
+def function_with_icontract(someArg: int) -> float:
+    return math.sqrt(someArg)
+
+
+@dpcontracts.ensure("some dummy contract", lambda args, result: result > 0)
+def function_with_dpcontracts(someArg: int) -> float:
+    return math.sqrt(someArg)
+
+
+def function_with_inline_contract(someArg: int) -> float:
+    result = math.sqrt(someArg)
+    assert result > 0
+    return result
+
+
+def function_without_contracts(someArg: int) -> float:
+    return math.sqrt(someArg)
+
+
+def measure_functions() -> None:
+    funcs = [
+        'function_with_icontract',
+        'function_with_dpcontracts',
+        'function_with_inline_contract',
+        'function_without_contracts'
+    ]
+
+    durations = [0.0] * len(funcs)
+
+    number = 10 * 1000
+
+    for i, func in enumerate(funcs):
+        duration = timeit.timeit(
+            "{}(198.4)".format(func),
+            setup="from __main__ import {}".format(func),
+            number=number)
+        durations[i] = duration
+
+    table = []  # type: List[List[str]]
+
+    for func, duration in zip(funcs, durations):
+        # yapf: disable
+        table.append([
+            '`{}`'.format(func),
+            '{:.2f} s'.format(duration),
+            '{:.2f} μs'.format(duration * 1000 * 1000 / number),
+            '{:.0f}%'.format(duration * 100 / durations[1])
+        ])
+        # yapf: enable
+
+    # yapf: disable
+    table_str = tabulate.tabulate(
+        table,
+        headers=['Case', 'Total time', 'Time per run', 'Relative time per run'],
+        colalign=('left', 'right', 'right', 'right'),
+        tablefmt='rst')
+    # yapf: enable
+
+    print(table_str)
+
+
+if __name__ == "__main__":
+    print("Benchmarking postcondition:")
+    print()
+    measure_functions()

--- a/benchmarks/against_dpcontracts/compare_postcondition.py
+++ b/benchmarks/against_dpcontracts/compare_postcondition.py
@@ -31,16 +31,11 @@ def function_with_inline_contract(someArg: int) -> float:
     return result
 
 
-def function_without_contracts(someArg: int) -> float:
-    return math.sqrt(someArg)
-
-
 def measure_functions() -> None:
     funcs = [
         'function_with_icontract',
         'function_with_dpcontracts',
-        'function_with_inline_contract',
-        'function_without_contracts'
+        'function_with_inline_contract'
     ]
 
     durations = [0.0] * len(funcs)

--- a/benchmarks/against_dpcontracts/compare_precondition.py
+++ b/benchmarks/against_dpcontracts/compare_precondition.py
@@ -39,8 +39,7 @@ def measure_functions() -> None:
     funcs = [
         'function_with_icontract',
         'function_with_dpcontracts',
-        'function_with_inline_contract',
-        'function_without_contracts'
+        'function_with_inline_contract'
     ]
 
     durations = [0.0] * len(funcs)

--- a/benchmarks/against_dpcontracts/compare_precondition.py
+++ b/benchmarks/against_dpcontracts/compare_precondition.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+"""
+Benchmark icontract against dpcontracts and no contracts.
+
+The benchmark was supplied by: https://github.com/Parquery/icontract/issues/142
+"""
+
+import math
+import timeit
+from typing import List
+
+import tabulate
+
+import icontract
+import dpcontracts
+
+
+@icontract.require(lambda someArg: someArg > 0)
+def function_with_icontract(someArg: int) -> float:
+    return math.sqrt(someArg)
+
+
+@dpcontracts.require("some dummy contract", lambda args: args.someArg > 0)
+def function_with_dpcontracts(someArg: int) -> float:
+    return math.sqrt(someArg)
+
+
+def function_with_inline_contract(someArg: int) -> float:
+    assert (someArg > 0)
+    return math.sqrt(someArg)
+
+
+def function_without_contracts(someArg: int) -> float:
+    return math.sqrt(someArg)
+
+
+def measure_functions() -> None:
+    funcs = [
+        'function_with_icontract',
+        'function_with_dpcontracts',
+        'function_with_inline_contract',
+        'function_without_contracts'
+    ]
+
+    durations = [0.0] * len(funcs)
+
+    number = 10 * 1000
+
+    for i, func in enumerate(funcs):
+        duration = timeit.timeit(
+            "{}(198.4)".format(func),
+            setup="from __main__ import {}".format(func),
+            number=number)
+        durations[i] = duration
+
+    table = []  # type: List[List[str]]
+
+    for func, duration in zip(funcs, durations):
+        # yapf: disable
+        table.append([
+            '`{}`'.format(func),
+            '{:.2f} s'.format(duration),
+            '{:.2f} μs'.format(duration * 1000 * 1000 / number),
+            '{:.0f}%'.format(duration * 100 / durations[1])
+        ])
+        # yapf: enable
+
+    # yapf: disable
+    table_str = tabulate.tabulate(
+        table,
+        headers=['Case', 'Total time', 'Time per run', 'Relative time per run'],
+        colalign=('left', 'right', 'right', 'right'),
+        tablefmt='rst')
+    # yapf: enable
+
+    print(table_str)
+
+
+if __name__ == "__main__":
+    print("Benchmarking precondition:")
+    print()
+    measure_functions()

--- a/benchmarks/benchmark_2.0.7.rst
+++ b/benchmarks/benchmark_2.0.7.rst
@@ -1,0 +1,170 @@
+Benchmarks
+==========
+We evaluated the computational costs incurred by using icontract in a couple of experiments. There are basically two
+types of costs caused by icontract: 1) extra parsing performed when you import the module regardless whether conditions
+are switched on or off and 2) run-time cost of verifying the contract.
+
+We assumed in all the experiments that the contract breaches are exceptionally seldom and thus need not to be analyzed.
+If you are interested in these additional experiments, please do let us know and create an issue on the github page.
+
+The source code of the benchmarks is available in
+`this directory <https://github.com/Parquery/icontract/tree/master/benchmarks>`_.
+All experiments were performed with Python 3.5.2+ on Intel(R) Core(TM) i7-4700MQ CPU @ 2.40GHz with 8 cores and
+4 GB RAM.
+
+We execute a short timeit snippet to bring the following measurements into context:
+
+.. code-block:: bash
+
+    python3 -m timeit -s 'import math' 'math.sqrt(1984.1234)'
+    10000000 loops, best of 3: 0.0679 usec per loop
+
+Important Note
+--------------
+The experiments were executed with icontract 2.0.7. While it would have been great to have benchmarks
+re-executed on each new version, that would require substantial effort on our side.
+Please run the scripts manually on your machine with the latest icontract version
+to obtain the current benchmark results.
+
+Import Cost
+-----------
+**Pre and post-conditions.**
+We generated a module with 100 functions. For each of these functions, we introduced a variable number of conditions and
+stop-watched how long it takes to import the module over 10 runs. Finally, we compared the import time of the module
+with contracts against the same module without any contracts in the code.
+
+The overhead is computed as the time difference between the total import time compared to the total import time of the
+module without the contracts.
+
++-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
+| Number of conditions per function | Total import time [milliseconds] | Overhead [milliseconds] | Overhead per condition and function [milliseconds] |
++===================================+==================================+=========================+====================================================+
+| None                              |                   795.59 ± 10.47 |                     N/A |                                                N/A |
++-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
+| 1                                 |                   919.53 ± 61.22 |                  123.93 |                                               1.24 |
++-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
+| 5                                 |                  1075.81 ± 59.87 |                  280.22 |                                               0.56 |
++-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
+| 10                                |                  1290.22 ± 90.04 |                  494.63 |                                               0.49 |
++-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
+| 1 disabled                        |                   833.60 ± 32.07 |                   37.41 |                                               0.37 |
++-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
+| 5 disabled                        |                   851.31 ± 66.93 |                   55.72 |                                               0.11 |
++-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
+| 10 disabled                       |                  897.90 ± 143.02 |                  101.41 |                                               0.10 |
++-----------------------------------+----------------------------------+-------------------------+----------------------------------------------------+
+
+As we can see in the table above, the overhead per condition is quite minimal (1.24 milliseconds in case of a single
+enabled contract). The overhead decreases as you add more conditions since the icontract has already initialized all the
+necessary fields in the function objects.
+
+When you disable the conditions, there is much less overhead (only 0.37 milliseconds, and decreasing). Since icontract
+returns immediately when the condition is disabled by implementation, we assume that the overhead coming from disabled
+conditions is mainly caused by Python interpreter parsing the code.
+
+
+**Invariants**. Analogously, to measure the overhead of the invariants, we generated a module with 100 classes.
+We varied the number of invariant conditions per class and measure the import time over 10 runs. The results
+are presented in the following table.
+
++--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+| Number of conditions per class | Total import time [milliseconds] | Overhead [milliseconds] | Overhead per condition and class [milliseconds] |
++================================+==================================+=========================+=================================================+
+| None                           |                   843.61 ± 28.21 |                     N/A |                                             N/A |
++--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+| 1                              |                  3409.71 ± 95.78 |                  2566.1 |                                           25.66 |
++--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+| 5                              |                 4005.93 ± 131.97 |                 3162.32 |                                            6.32 |
++--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+| 10                             |                 4801.82 ± 157.56 |                 3958.21 |                                            3.96 |
++--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+| 1 disabled                     |                   885.88 ± 44.24 |                   42.27 |                                            0.42 |
++--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+| 5 disabled                     |                  912.53 ± 101.91 |                   68.92 |                                            0.14 |
++--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+| 10 disabled                    |                  963.77 ± 161.76 |                  120.16 |                                            0.12 |
++--------------------------------+----------------------------------+-------------------------+-------------------------------------------------+
+
+Similar to pre and post-conditions, there is decreasing cost per condition as number of conditions increases since the
+icontract has all set up the fields in the class metadata. However, invariants are much more costly compared to pre and
+postconditions and their overhead should be considered if import time needs to be kept minimal.
+
+The overhead of the disabled invariants is attributed to the overhead of parsing the source file as icontract
+immediately returns from disabled invariants by implementation.
+
+Run-time Cost
+-------------
+We constructed four modules around a function which computes a square root. We used ``timeit`` module to measure the
+performance. Each module was imported as part of the setup.
+
+**No precondition**. This module does not check any preconditions and serves as a baseline.
+
+.. code-block: python
+
+    import math
+    def my_sqrt(x: float) -> float:
+        return math.sqrt(x)
+
+**Pre-condition as assert**. We check pre-conditions by an assert statement.
+
+.. code-block:: python
+
+    def my_sqrt(x: float) -> float:
+        assert x >= 0
+        return math.sqrt(x)
+
+**Pre-condition as separate function**. To mimick a more complex pre-condition, we encapsulate the assert in a separate
+function.
+
+.. code-block:: python
+
+    import math
+
+    def check_non_negative(x: float) -> None:
+        assert x >= 0
+
+    def my_sqrt(x: float) -> float:
+        check_non_negative(x)
+        return math.sqrt(x)
+
+**Pre-condition with icontract**. Finally, we compare against a module that uses icontract.
+
+.. code-block:: python
+
+    import math
+    import icontract
+
+    @icontract.require(lambda x: x >= 0)
+    def my_sqrt(x: float) -> float:
+        return math.sqrt(x)
+
+**Pre-condition with icontract, disabled**. We also perform a redundant check to verify that a disabled condition
+does not incur any run-time cost.
+
+The following table sumarizes the timeit results (10000000 loops, best of 3). The run time of the baseline is computed
+as:
+
+.. code-block: bash
+
+    $ python3 -m timeit -s 'import my_sqrt' 'my_sqrt.my_sqrt(1984.1234)'
+
+The run time of the other functions is computed analogously.
+
++---------------------+-------------------------+
+| Precondition        | Run time [microseconds] |
++=====================+=========================+
+| None                |                   0.168 |
++---------------------+-------------------------+
+| As assert           |                   0.203 |
++---------------------+-------------------------+
+| As function         |                   0.274 |
++---------------------+-------------------------+
+| icontract           |                    2.78 |
++---------------------+-------------------------+
+| icontract, disabled |                   0.165 |
++---------------------+-------------------------+
+
+The overhead of icontract is substantial. While this may be prohibitive for points where computational efficiency is
+more important than correctness, mind that the overhead is still in order of microseconds. In most practical scenarios,
+where a function is more complex and takes longer than a few microseconds to execute, such a tiny overhead is
+justified by the gains in correctness, development and maintenance time.

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -1,4 +1,11 @@
 """Decorate functions with contracts."""
+import icontract_meta
+
+__version__ = icontract_meta.__version__
+__author__ = icontract_meta.__author__
+__copyright__ = icontract_meta.__copyright__
+__license__ = icontract_meta.__license__
+__status__ = icontract_meta.__status__
 
 # pylint: disable=invalid-name
 # pylint: disable=protected-access

--- a/icontract_meta.py
+++ b/icontract_meta.py
@@ -1,0 +1,12 @@
+"""Define meta information about mapry package."""
+
+__title__ = 'icontract'
+__description__ = (
+    'Provide design-by-contract with informative violation messages.')
+__url__ = 'https://github.com/Parquery/icontract'
+__version__ = '2.3.2'
+__author__ = 'Marko Ristin'
+__author_email__ = 'marko.ristin@gmail.com'
+__license__ = 'MIT'
+__copyright__ = 'Copyright 2019 Parquery AG'
+__status__ = 'Production'

--- a/icontract_meta.py
+++ b/icontract_meta.py
@@ -4,7 +4,7 @@ __title__ = 'icontract'
 __description__ = (
     'Provide design-by-contract with informative violation messages.')
 __url__ = 'https://github.com/Parquery/icontract'
-__version__ = '2.3.2'
+__version__ = '2.3.2.post1'
 __author__ = 'Marko Ristin'
 __author_email__ = 'marko.ristin@gmail.com'
 __license__ = 'MIT'

--- a/precommit.py
+++ b/precommit.py
@@ -6,11 +6,70 @@ import pathlib
 import subprocess
 import sys
 
+import cpuinfo
+
+import icontract
+
+
+def benchmark_against_dpcontracts(repo_root: pathlib.Path, overwrite: bool) -> None:
+    """Run benchmars against dpcontracts and include them in the Readme."""
+    script_rel_paths = [
+        'benchmarks/against_dpcontracts/compare_invariant.py', 'benchmarks/against_dpcontracts/compare_precondition.py',
+        'benchmarks/against_dpcontracts/compare_postcondition.py'
+    ]
+
+    if not overwrite:
+        for i, script_rel_path in enumerate(script_rel_paths):
+            if i > 0:
+                print()
+            subprocess.check_call(['python3', str(repo_root / script_rel_path)])
+    else:
+        out = ['The following scripts were run:\n\n']
+        for script_rel_path in script_rel_paths:
+            out.append('* `{0} <https://github.com/Parquery/icontract/tree/master/{0}>`_\n'.format(script_rel_path))
+        out.append('\n')
+
+        out.append(('The benchmarks were executed on {}.\nWe used icontract {} and dpcontracts 0.6.0.\n\n').format(
+            cpuinfo.get_cpu_info()['brand'], icontract.__version__))
+
+        out.append('The following tables summarize the results.\n\n')
+        stdouts = []  # type: List[str]
+
+        for script_rel_path in script_rel_paths:
+            stdout = subprocess.check_output(['python3', str(repo_root / script_rel_path)]).decode()
+            stdouts.append(stdout)
+
+            out.append(stdout)
+            out.append('\n')
+
+        readme_path = repo_root / 'README.rst'
+        readme = readme_path.read_text()
+        marker_start = '.. Becnhmark report from precommit.py starts.'
+        marker_end = '.. Benchmark report from precommit.py ends.'
+        lines = readme.splitlines()
+
+        try:
+            index_start = lines.index(marker_start)
+        except ValueError as exc:
+            raise ValueError('Could not find the marker for the benchmarks in the {}: {}'.format(
+                readme_path, marker_start)) from exc
+
+        try:
+            index_end = lines.index(marker_end)
+        except ValueError as exc:
+            raise ValueError('Could not find the start marker for the benchmarks in the {}: {}'.format(
+                readme_path, marker_end)) from exc
+
+        assert index_start < index_end, 'Unexpected end marker before start marker for the benchmarks.'
+
+        lines = lines[:index_start + 1] + ['\n'] + (''.join(out)).splitlines() + ['\n'] + lines[index_end:]
+        readme_path.write_text('\n'.join(lines) + '\n')
+
+        print('\n\n'.join(stdouts))
+
 
 def main() -> int:
-    """"
-    Main routine
-    """
+    """"Execute main routine."""
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "--overwrite",
@@ -60,6 +119,9 @@ def main() -> int:
     # yapf: enable
 
     subprocess.check_call(["coverage", "report"])
+
+    print("Benchmarking against dpcontracts...")
+    benchmark_against_dpcontracts(repo_root=repo_root, overwrite=overwrite)
 
     print("Doctesting...")
     subprocess.check_call(["python3", "-m", "doctest", "README.rst"])

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,8 @@ import os
 
 from setuptools import setup, find_packages
 
+import icontract_meta
+
 # pylint: disable=redefined-builtin
 
 here = os.path.abspath(os.path.dirname(__file__))  # pylint: disable=invalid-name
@@ -16,13 +18,13 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as fid:
     long_description = fid.read()  # pylint: disable=invalid-name
 
 setup(
-    name='icontract',
-    version='2.3.2',
-    description='Provide design-by-contract with informative violation messages',
+    name=icontract_meta.__title__,
+    version=icontract_meta.__version__,
+    description=icontract_meta.__description__,
     long_description=long_description,
-    url='https://github.com/Parquery/icontract',
-    author='Marko Ristin',
-    author_email='marko@parquery.com',
+    url=icontract_meta.__url__,
+    author=icontract_meta.__author__,
+    author_email=icontract_meta.__author_email__,
     classifiers=[
         # yapf: disable
         'Development Status :: 5 - Production/Stable',
@@ -48,7 +50,10 @@ setup(
             'pydocstyle>=2.1.1,<3',
             'coverage>=4.5.1,<5',
             'docutils>=0.14,<1',
-            'pygments>=2.2.0,<3'
+            'pygments>=2.2.0,<3',
+            'dpcontracts==0.6.0',
+            'tabulate>=0.8.7,<1',
+            'py-cpuinfo>=5.0.0,<6'
             # yapf: enable
         ],
     },

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -116,21 +116,22 @@ class TestViolation(unittest.TestCase):
 
 
 class TestInvalid(unittest.TestCase):
-    def test_missing_old_snapshot(self) -> None:
+    def test_missing_snapshot_but_old_in_postcondition(self) -> None:
         @icontract.ensure(lambda OLD, val, lst: OLD.len_lst + 1 == len(lst))
         def some_func(lst: List[int], val: int) -> None:
             lst.append(val)
 
-        attribute_error = None  # type: Optional[AttributeError]
+        type_error = None  # type: Optional[TypeError]
         try:
             some_func([1], 2)
-        except AttributeError as err:
-            attribute_error = err
+        except TypeError as err:
+            type_error = err
 
-        self.assertIsNotNone(attribute_error)
-        self.assertEqual("The snapshot with the name 'len_lst' is not available in the OLD of a postcondition. "
-                         "Have you decorated the function with a corresponding snapshot decorator?",
-                         str(attribute_error))
+        self.assertIsNotNone(type_error)
+        self.assertEqual("The argument(s) of the postcondition have not been set: ['OLD']. "
+                         "Does the original function define them? Did you supply them in the call? "
+                         "Did you decorate the function with a snapshot to capture OLD values?",
+                         tests.error.wo_mandatory_location(str(type_error)))
 
     def test_conflicting_snapshots_with_argument_name(self) -> None:
         value_error = None  # type: Optional[ValueError]


### PR DESCRIPTION
This commit makes a couple of fixes to improve the computational
efficiency of the contracts. There was a performance regression when the
state was introduced (notably, `ExitStack` caused a lot of overhead).

This commit also introduces benchmarking into the continuous integration
(as part of the precommit.py script) so that we can continously monitor
the efficiency in the future.

Fixes #142 .