### PR TITLE
added support for development in Windows

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -688,7 +688,7 @@ snippet:
 
     some_func()
 
-Naïvely evaluating such preconditions and postconditions would result in endless recursions. Therefore, icontract
+NaÃƒÆ’Ã†â€™Ãƒâ€šÃ‚Â¯vely evaluating such preconditions and postconditions would result in endless recursions. Therefore, icontract
 suspends any further contract checking for a function when re-entering it for the second time while checking its
 contracts.
 
@@ -787,8 +787,8 @@ The following scripts were run:
 * `benchmarks/against_dpcontracts/compare_precondition.py <https://github.com/Parquery/icontract/tree/master/benchmarks/against_dpcontracts/compare_precondition.py>`_
 * `benchmarks/against_dpcontracts/compare_postcondition.py <https://github.com/Parquery/icontract/tree/master/benchmarks/against_dpcontracts/compare_postcondition.py>`_
 
-The benchmarks were executed on Intel(R) Core(TM) i7-4700MQ CPU @ 2.40GHz.
-We used icontract 2.3.4 and dpcontracts 0.6.0.
+The benchmarks were executed on Intel(R) Xeon(R) E-2276M  CPU @ 2.80GHz.
+We used Python 3.8.5, icontract 2.3.4 and dpcontracts 0.6.0.
 
 The following tables summarize the results.
 
@@ -797,9 +797,9 @@ Benchmarking invariant at __init__:
 =========================  ============  ==============  =======================
 Case                         Total time    Time per run    Relative time per run
 =========================  ============  ==============  =======================
-`ClassWithIcontract`             2.18 s         2.18 μs                     320%
-`ClassWithDpcontracts`           0.68 s         0.68 μs                     100%
-`ClassWithInlineContract`        0.42 s         0.42 μs                      62%
+`ClassWithIcontract`             1.51 s         1.51 μs                     313%
+`ClassWithDpcontracts`           0.48 s         0.48 μs                     100%
+`ClassWithInlineContract`        0.29 s         0.29 μs                      60%
 =========================  ============  ==============  =======================
 
 Benchmarking invariant at a function:
@@ -807,9 +807,9 @@ Benchmarking invariant at a function:
 =========================  ============  ==============  =======================
 Case                         Total time    Time per run    Relative time per run
 =========================  ============  ==============  =======================
-`ClassWithIcontract`             2.81 s         2.81 μs                     433%
-`ClassWithDpcontracts`           0.65 s         0.65 μs                     100%
-`ClassWithInlineContract`        0.33 s         0.33 μs                      51%
+`ClassWithIcontract`             2.18 s         2.18 μs                     435%
+`ClassWithDpcontracts`           0.50 s         0.50 μs                     100%
+`ClassWithInlineContract`        0.26 s         0.26 μs                      52%
 =========================  ============  ==============  =======================
 
 Benchmarking precondition:
@@ -817,9 +817,9 @@ Benchmarking precondition:
 ===============================  ============  ==============  =======================
 Case                               Total time    Time per run    Relative time per run
 ===============================  ============  ==============  =======================
-`function_with_icontract`              0.03 s         3.33 μs                       1%
-`function_with_dpcontracts`            2.79 s       278.95 μs                     100%
-`function_with_inline_contract`        0.00 s         0.14 μs                       0%
+`function_with_icontract`              0.03 s         2.96 μs                       5%
+`function_with_dpcontracts`            0.58 s        57.50 μs                     100%
+`function_with_inline_contract`        0.00 s         0.16 μs                       0%
 ===============================  ============  ==============  =======================
 
 Benchmarking postcondition:
@@ -827,9 +827,9 @@ Benchmarking postcondition:
 ===============================  ============  ==============  =======================
 Case                               Total time    Time per run    Relative time per run
 ===============================  ============  ==============  =======================
-`function_with_icontract`              0.04 s         3.50 μs                       1%
-`function_with_dpcontracts`            2.79 s       279.46 μs                     100%
-`function_with_inline_contract`        0.00 s         0.14 μs                       0%
+`function_with_icontract`              0.03 s         2.74 μs                       5%
+`function_with_dpcontracts`            0.55 s        55.33 μs                     100%
+`function_with_inline_contract`        0.00 s         0.16 μs                       0%
 ===============================  ============  ==============  =======================
 
 

--- a/benchmarks/against_dpcontracts/compare_invariant.py
+++ b/benchmarks/against_dpcontracts/compare_invariant.py
@@ -5,6 +5,8 @@ Benchmark icontract against dpcontracts and no contracts.
 
 The benchmark was supplied by: https://github.com/Parquery/icontract/issues/142
 """
+import os
+import sys
 import timeit
 from typing import List
 
@@ -12,7 +14,6 @@ import dpcontracts
 import tabulate
 
 import icontract
-
 
 @icontract.invariant(lambda self: len(self.parts) > 0)
 class ClassWithIcontract:
@@ -52,6 +53,15 @@ clses = [
     'ClassWithInlineContract',
 ]
 
+def writeln_utf8(text: str)->None:
+    """
+    write the text to STDOUT using UTF-8 encoding followed by a new-line character.
+
+    We can not use ``print()`` as we can not rely on the correct encoding in Windows.
+    See: https://stackoverflow.com/questions/31469707/changing-the-locale-preferred-encoding-in-python-3-in-windows
+    """
+    sys.stdout.buffer.write(text.encode('utf-8'))
+    sys.stdout.buffer.write(os.linesep.encode('utf-8'))
 
 def measure_invariant_at_init() -> None:
     durations = [0.0] * len(clses)
@@ -65,7 +75,7 @@ def measure_invariant_at_init() -> None:
             number=number)
         durations[i] = duration
 
-    print("Benchmarking invariant at __init__:\n")
+    writeln_utf8("Benchmarking invariant at __init__:\n")
     table = []  # type: List[List[str]]
 
     for cls, duration in zip(clses, durations):
@@ -86,7 +96,7 @@ def measure_invariant_at_init() -> None:
         tablefmt='rst')
     # yapf: enable
 
-    print(table_str)
+    writeln_utf8(table_str)
 
 
 def measure_invariant_at_function() -> None:
@@ -101,7 +111,7 @@ def measure_invariant_at_function() -> None:
             number=number)
         durations[i] = duration
 
-    print("Benchmarking invariant at a function:\n")
+    writeln_utf8("Benchmarking invariant at a function:\n")
     table = []  # type: List[List[str]]
 
     for cls, duration in zip(clses, durations):
@@ -122,10 +132,10 @@ def measure_invariant_at_function() -> None:
         tablefmt='rst')
     # yapf: enable
 
-    print(table_str)
+    writeln_utf8(table_str)
 
 
 if __name__ == "__main__":
     measure_invariant_at_init()
-    print()
+    writeln_utf8('')
     measure_invariant_at_function()

--- a/benchmarks/against_dpcontracts/compare_postcondition.py
+++ b/benchmarks/against_dpcontracts/compare_postcondition.py
@@ -6,6 +6,8 @@ Benchmark icontract against dpcontracts and no contracts.
 The benchmark was supplied by: https://github.com/Parquery/icontract/issues/142
 """
 import math
+import os
+import sys
 import timeit
 from typing import List
 
@@ -29,6 +31,16 @@ def function_with_inline_contract(someArg: int) -> float:
     result = math.sqrt(someArg)
     assert result > 0
     return result
+
+def writeln_utf8(text: str)->None:
+    """
+    write the text to STDOUT using UTF-8 encoding followed by a new-line character.
+
+    We can not use ``print()`` as we can not rely on the correct encoding in Windows.
+    See: https://stackoverflow.com/questions/31469707/changing-the-locale-preferred-encoding-in-python-3-in-windows
+    """
+    sys.stdout.buffer.write(text.encode('utf-8'))
+    sys.stdout.buffer.write(os.linesep.encode('utf-8'))
 
 
 def measure_functions() -> None:
@@ -69,10 +81,10 @@ def measure_functions() -> None:
         tablefmt='rst')
     # yapf: enable
 
-    print(table_str)
+    writeln_utf8(table_str)
 
 
 if __name__ == "__main__":
-    print("Benchmarking postcondition:")
-    print()
+    writeln_utf8("Benchmarking postcondition:")
+    writeln_utf8('')
     measure_functions()

--- a/benchmarks/against_dpcontracts/compare_precondition.py
+++ b/benchmarks/against_dpcontracts/compare_precondition.py
@@ -7,6 +7,8 @@ The benchmark was supplied by: https://github.com/Parquery/icontract/issues/142
 """
 
 import math
+import os
+import sys
 import timeit
 from typing import List
 
@@ -33,6 +35,16 @@ def function_with_inline_contract(someArg: int) -> float:
 
 def function_without_contracts(someArg: int) -> float:
     return math.sqrt(someArg)
+
+def writeln_utf8(text: str)->None:
+    """
+    write the text to STDOUT using UTF-8 encoding followed by a new-line character.
+
+    We can not use ``print()`` as we can not rely on the correct encoding in Windows.
+    See: https://stackoverflow.com/questions/31469707/changing-the-locale-preferred-encoding-in-python-3-in-windows
+    """
+    sys.stdout.buffer.write(text.encode('utf-8'))
+    sys.stdout.buffer.write(os.linesep.encode('utf-8'))
 
 
 def measure_functions() -> None:
@@ -73,10 +85,10 @@ def measure_functions() -> None:
         tablefmt='rst')
     # yapf: enable
 
-    print(table_str)
+    writeln_utf8(table_str)
 
 
 if __name__ == "__main__":
-    print("Benchmarking precondition:")
-    print()
+    writeln_utf8("Benchmarking precondition:")
+    writeln_utf8('')
     measure_functions()

--- a/precommit.py
+++ b/precommit.py
@@ -3,8 +3,10 @@
 import argparse
 import os
 import pathlib
+import platform
 import subprocess
 import sys
+from typing import List
 
 import cpuinfo
 
@@ -22,21 +24,22 @@ def benchmark_against_dpcontracts(repo_root: pathlib.Path, overwrite: bool) -> N
         for i, script_rel_path in enumerate(script_rel_paths):
             if i > 0:
                 print()
-            subprocess.check_call(['python3', str(repo_root / script_rel_path)])
+            subprocess.check_call([sys.executable, str(repo_root / script_rel_path)])
     else:
         out = ['The following scripts were run:\n\n']
         for script_rel_path in script_rel_paths:
             out.append('* `{0} <https://github.com/Parquery/icontract/tree/master/{0}>`_\n'.format(script_rel_path))
         out.append('\n')
 
-        out.append(('The benchmarks were executed on {}.\nWe used icontract {} and dpcontracts 0.6.0.\n\n').format(
-            cpuinfo.get_cpu_info()['brand'], icontract.__version__))
+        out.append(
+            ('The benchmarks were executed on {}.\nWe used Python {}, icontract {} and dpcontracts 0.6.0.\n\n').format(
+                cpuinfo.get_cpu_info()['brand'], platform.python_version(), icontract.__version__))
 
         out.append('The following tables summarize the results.\n\n')
         stdouts = []  # type: List[str]
 
         for script_rel_path in script_rel_paths:
-            stdout = subprocess.check_output(['python3', str(repo_root / script_rel_path)]).decode()
+            stdout = subprocess.check_output([sys.executable, str(repo_root / script_rel_path)]).decode()
             stdouts.append(stdout)
 
             out.append(stdout)
@@ -63,9 +66,11 @@ def benchmark_against_dpcontracts(repo_root: pathlib.Path, overwrite: bool) -> N
         assert index_start < index_end, 'Unexpected end marker before start marker for the benchmarks.'
 
         lines = lines[:index_start + 1] + ['\n'] + (''.join(out)).splitlines() + ['\n'] + lines[index_end:]
-        readme_path.write_text('\n'.join(lines) + '\n')
+        readme_path.write_text('\n'.join(lines) + '\n', encoding='utf-8')
 
-        print('\n\n'.join(stdouts))
+        # This is necessary so that the benchmarks do not complain on a Windows machine if the console encoding has not
+        # been properly set.
+        sys.stdout.buffer.write(('\n\n'.join(stdouts) + '\n').encode('utf-8'))
 
 
 def main() -> int:
@@ -90,20 +95,20 @@ def main() -> int:
                 "yapf", "--in-place", "--style=style.yapf", "--recursive", "tests", "icontract", "setup.py",
                 "precommit.py"
             ],
-            cwd=repo_root.as_posix())
+            cwd=str(repo_root))
     else:
         subprocess.check_call(
             ["yapf", "--diff", "--style=style.yapf", "--recursive", "tests", "icontract", "setup.py", "precommit.py"],
-            cwd=repo_root.as_posix())
+            cwd=str(repo_root))
 
     print("Mypy'ing...")
-    subprocess.check_call(["mypy", "--strict", "icontract", "tests"], cwd=repo_root.as_posix())
+    subprocess.check_call(["mypy", "--strict", "icontract", "tests"], cwd=str(repo_root))
 
     print("Pylint'ing...")
-    subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "icontract"], cwd=repo_root.as_posix())
+    subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "icontract"], cwd=str(repo_root))
 
     print("Pydocstyle'ing...")
-    subprocess.check_call(["pydocstyle", "icontract"], cwd=repo_root.as_posix())
+    subprocess.check_call(["pydocstyle", "icontract"], cwd=str(repo_root))
 
     print("Testing...")
     env = os.environ.copy()
@@ -114,7 +119,7 @@ def main() -> int:
         ["coverage", "run",
          "--source", "icontract",
          "-m", "unittest", "discover", "tests"],
-        cwd=repo_root.as_posix(),
+        cwd=str(repo_root),
         env=env)
     # yapf: enable
 
@@ -124,12 +129,12 @@ def main() -> int:
     benchmark_against_dpcontracts(repo_root=repo_root, overwrite=overwrite)
 
     print("Doctesting...")
-    subprocess.check_call(["python3", "-m", "doctest", "README.rst"])
+    subprocess.check_call([sys.executable, "-m", "doctest", "README.rst"])
     for pth in (repo_root / "icontract").glob("**/*.py"):
-        subprocess.check_call(["python3", "-m", "doctest", pth.as_posix()])
+        subprocess.check_call([sys.executable, "-m", "doctest", str(pth)])
 
     print("Checking the restructured text of the readme...")
-    subprocess.check_call(['python3', 'setup.py', 'check', '--restructuredtext', '--strict'])
+    subprocess.check_call([sys.executable, 'setup.py', 'check', '--restructuredtext', '--strict'])
 
     return 0
 

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -6,6 +6,7 @@
 
 import functools
 import pathlib
+import textwrap
 import time
 import unittest
 from typing import Optional, Callable, Any  # pylint: disable=unused-import
@@ -127,10 +128,16 @@ class TestViolation(unittest.TestCase):
         except icontract.ViolationError as err:
             violation_error = err
 
+        # This dummy path is necessary to obtain the class name.
+        dummy_path = pathlib.Path('/also/doesnt/exist')
+
         self.assertIsNotNone(violation_error)
-        self.assertEqual("path.exists():\n"
-                         "path was PosixPath('/doesnt/exist/test_contract')\n"
-                         "path.exists() was False", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent('''\
+                path.exists():
+                path was {}('/doesnt/exist/test_contract')
+                path.exists() was False''').format(dummy_path.__class__.__name__),
+            tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_multiple_comparators(self) -> None:
         @icontract.require(lambda x: 0 < x < 3)

--- a/tests/test_represent.py
+++ b/tests/test_represent.py
@@ -4,6 +4,7 @@
 
 import pathlib
 import reprlib
+import textwrap
 import unittest
 from typing import Optional, List, Tuple  # pylint: disable=unused-import
 
@@ -380,11 +381,16 @@ class TestReprValues(unittest.TestCase):
         except icontract.ViolationError as err:
             violation_error = err
 
+        # This dummy path is necessary to obtain the class name.
+        dummy_path = pathlib.Path('/also/doesnt/exist')
+
         self.assertIsNotNone(violation_error)
-        self.assertEqual("all(single_res[1].is_absolute() for single_res in result):\n"
-                         "all(single_res[1].is_absolute() for single_res in result) was False\n"
-                         "result was [(PosixPath('/home/file1'), PosixPath('home/file2'))]",
-                         tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent('''\
+                 all(single_res[1].is_absolute() for single_res in result):
+                 all(single_res[1].is_absolute() for single_res in result) was False
+                 result was [({0}('/home/file1'), {0}('home/file2'))]''').format(dummy_path.__class__.__name__),
+            tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_generator_expression_multiple_for(self) -> None:
         lst = [[1, 2], [3]]
@@ -660,16 +666,22 @@ class TestClass(unittest.TestCase):
         except icontract.ViolationError as err:
             violation_error = err
 
+        # This dummy path is necessary to obtain the class name.
+        dummy_path = pathlib.Path('/just/a/dummy/path')
+
         self.assertIsNotNone(violation_error)
-        self.assertEqual("pathlib.Path(str(gt_zero(self.b.c(x=0).x() + 12.2 * z))) is None:\n"
-                         "gt_zero(self.b.c(x=0).x() + 12.2 * z) was True\n"
-                         "pathlib.Path(str(gt_zero(self.b.c(x=0).x() + 12.2 * z))) was PosixPath('True')\n"
-                         "self was A()\n"
-                         "self.b was B()\n"
-                         "self.b.c(x=0) was C(x=0)\n"
-                         "self.b.c(x=0).x() was 0\n"
-                         "str(gt_zero(self.b.c(x=0).x() + 12.2 * z)) was 'True'\n"
-                         "z was 10", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent('''\
+                pathlib.Path(str(gt_zero(self.b.c(x=0).x() + 12.2 * z))) is None:
+                gt_zero(self.b.c(x=0).x() + 12.2 * z) was True
+                pathlib.Path(str(gt_zero(self.b.c(x=0).x() + 12.2 * z))) was {}('True')
+                self was A()
+                self.b was B()
+                self.b.c(x=0) was C(x=0)
+                self.b.c(x=0).x() was 0
+                str(gt_zero(self.b.c(x=0).x() + 12.2 * z)) was 'True'
+                z was 10''').format(dummy_path.__class__.__name__),
+            tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestClosures(unittest.TestCase):


### PR DESCRIPTION
This patch fixes quite some minor issues with the pre-commit script and
the unit tests so that they also run in Windows.

This finally enables contributors to work on Windows. Mind that the
library worked on Windows even before, so this change affects only the
*development*.