### PR TITLE
bumped to version 2.3.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+2.3.5
+=====
+* Disabled invariant checks during the construction to avoid attribute errors
+  on uninitialized attributes
+
+2.3.4
+=====
+* Added ``icontract_meta`` to ``setup.py``
+* Noted that contracts on ``*args`` and ``**kwargs`` are known issues
+
 2.3.3
 =====
 * Fixed performance regression due to state

--- a/icontract_meta.py
+++ b/icontract_meta.py
@@ -4,7 +4,7 @@ __title__ = 'icontract'
 __description__ = (
     'Provide design-by-contract with informative violation messages.')
 __url__ = 'https://github.com/Parquery/icontract'
-__version__ = '2.3.4'
+__version__ = '2.3.5'
 __author__ = 'Marko Ristin'
 __author_email__ = 'marko.ristin@gmail.com'
 __license__ = 'MIT'


### PR DESCRIPTION
* Disabled invariant checks during the construction to avoid attribute errors
  on uninitialized attributes