### PR TITLE
Bumped to 2.3.6

### DIFF
--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -6,7 +6,7 @@
 # used to be referenced from setup.py and this file) since readthedocs had
 # problems with installing icontract through pip on their servers with
 # imports in setup.py.
-__version__ = '2.3.5'
+__version__ = '2.3.6'  # Don't forget to update the version in setup.py!
 __author__ = 'Marko Ristin'
 __copyright__ = 'Copyright 2019 Parquery AG'
 __license__ = 'MIT'

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,8 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as fid:
 # imports in setup.py.
 setup(
     name='icontract',
-    version='2.3.5',
-    description=('Provide design-by-contract with informative violation messages.'),
+    version='2.3.6',  # Don't forget to update the version in __init__.py!
+    description='Provide design-by-contract with informative violation messages.',
     long_description=long_description,
     url='https://github.com/Parquery/icontract',
     author='Marko Ristin',


### PR DESCRIPTION
* Denormalized icontract_meta so that icontract can be installed on
  readthedocs.