### PR TITLE
Added support for named expressions in contracts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ python:
   - "3.5"
   - "3.6"
   - "3.7"
-  - "3.8"
+  - "3.8.5"
 install:
   - pip3 install -e .[dev]
   - pip3 install coveralls

--- a/precommit.py
+++ b/precommit.py
@@ -24,6 +24,10 @@ def main() -> int:
 
     print("YAPF'ing...")
     yapf_targets = ["tests", "icontract", "setup.py", "precommit.py", "benchmark.py", "benchmarks", "tests_with_others"]
+
+    if sys.version_info >= (3, 8, 5):
+        yapf_targets.append('tests_3_8')
+
     if overwrite:
         subprocess.check_call(
             ["yapf", "--in-place", "--style=style.yapf", "--recursive"] + yapf_targets, cwd=str(repo_root))
@@ -32,10 +36,18 @@ def main() -> int:
             ["yapf", "--diff", "--style=style.yapf", "--recursive"] + yapf_targets, cwd=str(repo_root))
 
     print("Mypy'ing...")
-    subprocess.check_call(["mypy", "--strict", "icontract", "tests"], cwd=str(repo_root))
+    mypy_targets = ["icontract", "tests"]
+    if sys.version_info >= (3, 8):
+        mypy_targets.append('tests_3_8')
+
+    subprocess.check_call(["mypy", "--strict"] + mypy_targets, cwd=str(repo_root))
 
     print("Pylint'ing...")
-    subprocess.check_call(["pylint", "--rcfile=pylint.rc", "tests", "icontract"], cwd=str(repo_root))
+    pylint_targets = ['icontract', 'tests']
+
+    if sys.version_info >= (3, 8):
+        pylint_targets.append('tests_3_8')
+    subprocess.check_call(["pylint", "--rcfile=pylint.rc"] + pylint_targets, cwd=str(repo_root))
 
     print("Pydocstyle'ing...")
     subprocess.check_call(["pydocstyle", "icontract"], cwd=str(repo_root))
@@ -45,10 +57,14 @@ def main() -> int:
     env['ICONTRACT_SLOW'] = 'true'
 
     # yapf: disable
+    unittest_targets = ['tests']
+    if sys.version_info > (3, 8):
+        unittest_targets.append('tests_3_8')
+
     subprocess.check_call(
         ["coverage", "run",
          "--source", "icontract",
-         "-m", "unittest", "discover", "tests"],
+         "-m", "unittest", "discover"] + unittest_targets,
         cwd=str(repo_root),
         env=env)
     # yapf: enable

--- a/tests_3_8/__init__.py
+++ b/tests_3_8/__init__.py
@@ -1,0 +1,7 @@
+"""
+Test Python 3.8-specific features.
+
+For example, one such feature is walrus operator used in named expressions.
+We have to exclude these tests running on prior versions of Python since the syntax would be considered
+invalid.
+"""

--- a/tests_3_8/test_represent.py
+++ b/tests_3_8/test_represent.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-docstring,invalid-name,too-many-public-methods,no-self-use
+# pylint: disable=unused-argument
+
+import textwrap
+import unittest
+from typing import Optional  # pylint: disable=unused-import
+
+import icontract._represent
+import tests.error
+import tests.mock
+
+
+class TestReprValues(unittest.TestCase):
+    def test_named_expression(self) -> None:
+        @icontract.require(lambda x: (t := x + 1) and t > 1)  # pylint: disable=undefined-variable
+        def func(x: int) -> int:
+            return x
+
+        violation_err = None  # type: Optional[icontract.ViolationError]
+        try:
+            func(x=0)
+        except icontract.ViolationError as err:
+            violation_err = err
+
+        self.assertIsNotNone(violation_err)
+        self.assertEqual(
+            textwrap.dedent('''\
+                (t := x + 1) and t > 1:
+                t was 1
+                x was 0'''), tests.error.wo_mandatory_location(str(violation_err)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Named expressions were [introduced recently in Python 3.8][1].
This patch updates icontract's representation module so that they can be
properly recomputed and represented in the violation messages.

Fixes #164.

[1]: https://www.python.org/dev/peps/pep-0572/