### PR TITLE
Added support for recomputation of f-strings

### DIFF
--- a/icontract/_represent.py
+++ b/icontract/_represent.py
@@ -55,6 +55,17 @@ class Visitor(ast.NodeVisitor):
         self.reprs = dict()  # type: MutableMapping[str, str]
         self._atok = atok
 
+    if sys.version_info >= (3, 6):
+        # pylint: disable=no-member
+        def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
+            """Show the whole joined strings without descending into the values."""
+            if node in self._recomputed_values:
+                value = self._recomputed_values[node]
+
+                if _representable(value=value):
+                    text = self._atok.get_text(node)
+                    self.reprs[text] = value
+
     def visit_Name(self, node: ast.Name) -> None:
         """
         Resolve the name from the variable look-up and the built-ins.

--- a/precommit.py
+++ b/precommit.py
@@ -57,14 +57,10 @@ def main() -> int:
     env['ICONTRACT_SLOW'] = 'true'
 
     # yapf: disable
-    unittest_targets = ['tests']
-    if sys.version_info > (3, 8):
-        unittest_targets.append('tests_3_8')
-
     subprocess.check_call(
         ["coverage", "run",
          "--source", "icontract",
-         "-m", "unittest", "discover"] + unittest_targets,
+         "-m", "unittest", "discover"],
         cwd=str(repo_root),
         env=env)
     # yapf: enable

--- a/tests_3_6/__init__.py
+++ b/tests_3_6/__init__.py
@@ -1,0 +1,12 @@
+"""
+Test Python 3.6-specific features.
+
+For example, one such feature is literal string interpolation.
+"""
+
+import sys
+
+if sys.version_info < (3, 6):
+    def load_tests(loader, suite, pattern):  # pylint: disable=unused-argument
+        """Ignore all the tests for lower Python versions."""
+        return suite

--- a/tests_3_6/test_represent.py
+++ b/tests_3_6/test_represent.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-docstring,invalid-name,too-many-public-methods,no-self-use
+# pylint: disable=unused-argument
+
+import textwrap
+import unittest
+import math
+from typing import Optional  # pylint: disable=unused-import
+
+import icontract._represent
+import tests.error
+import tests.mock
+
+
+class TestLiteralStringInterpolation(unittest.TestCase):
+    def test_plain_string(self) -> None:
+        @icontract.require(lambda x: f"something" == '')
+        def func(x: float) -> float:
+            return x
+
+        violation_err = None  # type: Optional[icontract.ViolationError]
+        try:
+            func(x=0)
+        except icontract.ViolationError as err:
+            violation_err = err
+
+        self.assertIsNotNone(violation_err)
+        self.assertEqual(
+            'f"something" == \'\': f"something" was \'something\'',
+            tests.error.wo_mandatory_location(str(violation_err)))
+
+    def test_simple_interpolation(self) -> None:
+        @icontract.require(lambda x: f"{x}" == '')
+        def func(x: float) -> float:
+            return x
+
+        violation_err = None  # type: Optional[icontract.ViolationError]
+        try:
+            func(x=0)
+        except icontract.ViolationError as err:
+            violation_err = err
+
+        self.assertIsNotNone(violation_err)
+        self.assertEqual(
+            'f"{x}" == \'\': f"{x}" was \'0\'',
+            tests.error.wo_mandatory_location(str(violation_err)))
+
+    def test_string_formatting(self) -> None:
+        @icontract.require(lambda x: f"{x!s}" == '')
+        def func(x: float) -> float:
+            return x
+
+        violation_err = None  # type: Optional[icontract.ViolationError]
+        try:
+            func(x=1.984)
+        except icontract.ViolationError as err:
+            violation_err = err
+
+        self.assertIsNotNone(violation_err)
+        self.assertEqual(
+            'f"{x!s}" == \'\': f"{x!s}" was \'1.984\'',
+            tests.error.wo_mandatory_location(str(violation_err)))
+
+    def test_repr_formatting(self) -> None:
+        @icontract.require(lambda x: f"{x!r}" == '')
+        def func(x: float) -> float:
+            return x
+
+        violation_err = None  # type: Optional[icontract.ViolationError]
+        try:
+            func(x=1.984)
+        except icontract.ViolationError as err:
+            violation_err = err
+
+        self.assertIsNotNone(violation_err)
+        self.assertEqual(
+            'f"{x!r}" == \'\': f"{x!r}" was \'1.984\'',
+            tests.error.wo_mandatory_location(str(violation_err)))
+
+    def test_ascii_formatting(self) -> None:
+        @icontract.require(lambda x: f"{x!a}" == '')
+        def func(x: float) -> float:
+            return x
+
+        violation_err = None  # type: Optional[icontract.ViolationError]
+        try:
+            func(x=1.984)
+        except icontract.ViolationError as err:
+            violation_err = err
+
+        self.assertIsNotNone(violation_err)
+        self.assertEqual(
+            'f"{x!a}" == \'\': f"{x!a}" was \'1.984\'',
+            tests.error.wo_mandatory_location(str(violation_err)))
+
+    def test_format_spec(self) -> None:
+        @icontract.require(lambda x: f"{x:.3}" == '')
+        def func(x: float) -> float:
+            return x
+
+        violation_err = None  # type: Optional[icontract.ViolationError]
+        try:
+            func(x=1.984)
+        except icontract.ViolationError as err:
+            violation_err = err
+
+        self.assertIsNotNone(violation_err)
+        self.assertEqual(
+            'f"{x:.3}" == \'\': f"{x:.3}" was \'1.98\'',
+            tests.error.wo_mandatory_location(str(violation_err)))
+
+    def test_conversion_and_format_spec(self) -> None:
+        @icontract.require(lambda x: f"{x!r:.3}" == '')
+        def func(x: float) -> float:
+            return x
+
+        violation_err = None  # type: Optional[icontract.ViolationError]
+        try:
+            func(x=1.984)
+        except icontract.ViolationError as err:
+            violation_err = err
+
+        self.assertIsNotNone(violation_err)
+        self.assertEqual(
+            'f"{x!r:.3}" == \'\': f"{x!r:.3}" was \'1.9\'',
+            tests.error.wo_mandatory_location(str(violation_err)))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests_3_8/__init__.py
+++ b/tests_3_8/__init__.py
@@ -5,3 +5,11 @@ For example, one such feature is walrus operator used in named expressions.
 We have to exclude these tests running on prior versions of Python since the syntax would be considered
 invalid.
 """
+
+import sys
+
+if sys.version_info < (3, 8):
+
+    def load_tests(loader, suite, pattern):  # pylint: disable=unused-argument
+        """Ignore all the tests for lower Python versions."""
+        return suite


### PR DESCRIPTION
The f-strings (a.k.a. literal string interpolation) is a feature in
Python 3.6 which was not supported in the recompute module of icontract.
This patch adds the recomputation and representation of the f-strings.

Fixes #169.