### PR TITLE
Tested with `dataclasses.dataclass`

### DIFF
--- a/tests_3_7/__init__.py
+++ b/tests_3_7/__init__.py
@@ -1,0 +1,13 @@
+"""
+Test Python 3.-specific features.
+
+For example, one such feature is decorator ``dataclasses.dataclass``.
+"""
+
+import sys
+
+if sys.version_info < (3, 7):
+
+    def load_tests(loader, suite, pattern):  # pylint: disable=unused-argument
+        """Ignore all the tests for lower Python versions."""
+        return suite

--- a/tests_3_7/test_invariant.py
+++ b/tests_3_7/test_invariant.py
@@ -1,0 +1,52 @@
+# pylint: disable=missing-docstring
+# pylint: disable=invalid-name
+# pylint: disable=unused-argument
+# pylint: disable=no-member
+import dataclasses
+import textwrap
+import unittest
+from typing import NamedTuple, Optional  # pylint: disable=unused-import
+
+import icontract
+import tests.error
+
+
+class TestOK(unittest.TestCase):
+    def test_on_dataclass(self) -> None:
+        @icontract.invariant(lambda self: self.first > 0)
+        @dataclasses.dataclass
+        class RightHalfPlanePoint:
+            first: int
+            second: int
+
+        _ = RightHalfPlanePoint(1, 0)
+
+        self.assertEqual('Create and return a new object.  See help(type) for accurate signature.',
+                         RightHalfPlanePoint.__new__.__doc__)
+
+
+class TestViolation(unittest.TestCase):
+    def test_on_dataclass(self) -> None:
+        @icontract.invariant(lambda self: self.second > 0)
+        @icontract.invariant(lambda self: self.first > 0)
+        @dataclasses.dataclass
+        class RightHalfPlanePoint:
+            first: int
+            second: int
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            _ = RightHalfPlanePoint(1, -1)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual(
+            textwrap.dedent('''\
+            self.second > 0:
+            self was TestViolation.test_on_dataclass.<locals>.RightHalfPlanePoint(first=1, second=-1)
+            self.second was -1'''), tests.error.wo_mandatory_location(str(violation_error)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This patch adds test with `dataclasses.dataclass` decoretor to verify
that the invariants are correctly handled. This is because it turned out
there was a bug when handling named tuples (see issue #171).