### PR TITLE
Tested with typeguard

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -742,6 +742,37 @@ Sphinx
 We implemented a Sphinx extension to include contracts in the documentation. The extension is available as a package
 `sphinx-icontract <https://pypi.org/project/sphinx-icontract>`_.
 
+Checking Types at Runtime
+-------------------------
+Icontract focuses on logical contracts in the code. Theoretically, you could use icontract to check the types
+at runtime and condition the contracts using
+`material implication <https://en.wikipedia.org/wiki/Material_implication_(rule_of_inference)>`_:
+
+.. code-block:: python
+
+        @icontract.require(lambda x: not isinstance(x, int) or x > 0)
+        @icontract.require(lambda x: not isinstance(x, str) or x.startswith('x-'))
+        def some_func(x: Any) -> None
+            ...
+
+This is a good solution if your code lacks type annotations or if you do not know the type in advance.
+
+However, if you already annotated the code with the type annotations, re-stating the types in the contracts
+breaks the `DRY principle <https://en.wikipedia.org/wiki/Don%27t_repeat_yourself>`_ and makes the code
+unnecessarily hard to maintain and read:
+
+.. code-block:: python
+
+        @icontract.require(lambda x: isinstance(x, int))
+        def some_func(x: int) -> None
+            ...
+
+Elegant runtime type checks are out of icontract's scope. We would recommend you to use one of the available
+libraries specialized only on such checks such as `typeguard <https://pypi.org/project/typeguard/>`_.
+
+The icontract's test suite explicitly includes tests to make sure that icontract and typeguard work well together and
+to enforce their interplay in the future.
+
 Known Issues
 ============
 **Integration with ``help()``**. We wanted to include the contracts in the output of ``help()``. Unfortunately,

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ setup(
             'pygments>=2.2.0,<3',
             'dpcontracts==0.6.0',
             'tabulate>=0.8.7,<1',
-            'py-cpuinfo>=5.0.0,<6'
+            'py-cpuinfo>=5.0.0,<6',
+            'typeguard>=2,<3'
             # yapf: enable
         ] + (['deal==4.1.0'] if sys.version_info >= (3, 8) else []),
     },

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1,0 +1,207 @@
+# pylint: disable=missing-docstring
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name
+# pylint: disable=unused-argument
+# pylint: disable=no-member
+
+import textwrap
+import unittest
+from typing import Optional
+
+import typeguard
+
+import icontract
+import tests.error
+
+
+class TestPrecondition(unittest.TestCase):
+    def test_both_precondition_and_typeguard_ok(self) -> None:
+        @typeguard.typechecked
+        @icontract.require(lambda x: x > 0)
+        def some_func(x: int) -> None:
+            pass
+
+        some_func(1)
+
+    def test_precondition_ok_and_typeguard_fails(self) -> None:
+        class A:
+            def is_ok(self) -> bool:
+                return True
+
+        class B:
+            def is_ok(self) -> bool:
+                return True
+
+        @typeguard.typechecked
+        @icontract.require(lambda x: x.is_ok())
+        def some_func(x: A) -> None:
+            pass
+
+        b = B()
+        type_error = None  # type: Optional[TypeError]
+        try:
+            some_func(b)
+        except TypeError as err:
+            type_error = err
+
+        expected = 'type of argument "x" must be '
+        self.assertEqual(expected, str(type_error)[:len(expected)])
+
+    def test_precondition_fails_and_typeguard_ok(self) -> None:
+        @typeguard.typechecked
+        @icontract.require(lambda x: x > 0)
+        def some_func(x: int) -> None:
+            pass
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            some_func(-10)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual('x > 0: x was -10', tests.error.wo_mandatory_location(str(violation_error)))
+
+
+class TestInvariant(unittest.TestCase):
+    def test_both_invariant_and_typeguard_ok(self) -> None:
+        @typeguard.typechecked
+        @icontract.invariant(lambda self: self.x > 0)
+        class A:
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+            def do_something(self, y: int) -> None:
+                self.x += y
+
+        a = A(x=1)
+        a.do_something(y=2)
+
+    def test_invariant_ok_and_typeguard_fails(self) -> None:
+        class A:
+            def is_ok(self) -> bool:
+                return True
+
+        class B:
+            def is_ok(self) -> bool:
+                return True
+
+        @typeguard.typechecked
+        @icontract.invariant(lambda self: self.x.is_ok())
+        class C:
+            def __init__(self, a: A) -> None:
+                self.a = a
+
+        b = B()
+
+        type_error = None  # type: Optional[TypeError]
+        try:
+            _ = C(a=b)  # type: ignore
+        except TypeError as err:
+            type_error = err
+
+        expected = 'type of argument "a" must be '
+        self.assertEqual(expected, str(type_error)[:len(expected)])
+
+    def test_invariant_fails_and_typeguard_ok(self) -> None:
+        @typeguard.typechecked
+        @icontract.invariant(lambda self: self.x > 0)
+        class A:
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+            def __repr__(self) -> str:
+                return "an instance of A"
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            _ = A(-1)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual(
+            textwrap.dedent('''\
+                self.x > 0:
+                self was an instance of A
+                self.x was -1'''), tests.error.wo_mandatory_location(str(violation_error)))
+
+
+class TestInheritance(unittest.TestCase):
+    def test_both_invariant_and_typeguard_ok(self) -> None:
+        @typeguard.typechecked
+        @icontract.invariant(lambda self: self.x > 0)
+        class A(icontract.DBC):
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+            def do_something(self, y: int) -> None:
+                self.x += y
+
+        class B(A):
+            pass
+
+        b = B(x=1)
+        b.do_something(y=2)
+
+    def test_invariant_ok_and_typeguard_fails(self) -> None:
+        class A:
+            def is_ok(self) -> bool:
+                return True
+
+        class B:
+            def is_ok(self) -> bool:
+                return True
+
+        @typeguard.typechecked
+        @icontract.invariant(lambda self: self.x.is_ok())
+        class C(icontract.DBC):
+            def __init__(self, a: A) -> None:
+                self.a = a
+
+        class D(C):
+            pass
+
+        b = B()
+
+        type_error = None  # type: Optional[TypeError]
+        try:
+            _ = D(a=b)  # type: ignore
+        except TypeError as err:
+            type_error = err
+
+        self.assertIsNotNone(type_error)
+
+        expected = 'type of argument "a" must be '
+        self.assertEqual(expected, str(type_error)[:len(expected)])
+
+    def test_invariant_fails_and_typeguard_ok(self) -> None:
+        @typeguard.typechecked
+        @icontract.invariant(lambda self: self.x > 0)
+        class A:
+            def __init__(self, x: int) -> None:
+                self.x = x
+
+            def __repr__(self) -> str:
+                return "an instance of A"
+
+        class B(A):
+            def __repr__(self) -> str:
+                return "an instance of B"
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            _ = B(-1)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual(
+            textwrap.dedent('''\
+                self.x > 0:
+                self was an instance of B
+                self.x was -1'''), tests.error.wo_mandatory_location(str(violation_error)))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This patch introduces tests to make sure that icontract and typeguard
can play well together. Additionally, we hint in the Readme that users
should use typeguard instead of icontract whenever they already
annotated the code with type annotations.

This is related to issue #174 .