### PR TITLE
Added special arguments `_ARGS` and `_KWARGS`

### DIFF
--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -52,7 +52,15 @@ def _kwargs_from_call(param_names: List[str], kwdefaults: Dict[str, Any], args: 
     :return: resolved arguments as they would be passed to the function
     """
     # pylint: disable=too-many-arguments
-    resolved_kwargs = dict()  # type: MutableMapping[str, Any]
+
+    # (Marko Ristin, 2020-12-01)
+    # Insert _ARGS and _KWARGS preemptively even if they are not needed by any contract.
+    # This makes the code logic much simpler since we do not explicitly check if a contract would
+    # need them, though it might incur a subtle computational overhead
+    # (*e.g.*, when the contracts do not need them or don't use any argument at all).
+    # We need to have a concrete issue where profiling helps us determine if this is a real
+    # bottleneck or not and not optimize for no real benefit.
+    resolved_kwargs = {'_ARGS': args, '_KWARGS': kwargs}
 
     # Set the default argument values as condition parameters.
     for param_name, param_value in kwdefaults.items():
@@ -224,7 +232,9 @@ def _assert_postcondition(contract: Contract, resolved_kwargs: Mapping[str, Any]
     both argument values captured in snapshots and actual argument values and the result of a function.
 
     :param contract: contract to be verified
-    :param resolved_kwargs: resolved keyword arguments (including the default values, ``result`` and ``OLD``)
+    :param resolved_kwargs:
+        resolved keyword arguments (including the default values, ``result``,``OLD``
+        ``_ARGS`` and ``_KWARGS``)
     :return:
     """
     assert 'result' in resolved_kwargs, \
@@ -324,6 +334,16 @@ def decorate_with_checker(func: CallableT) -> CallableT:
         "per function)."
 
     sign = inspect.signature(func)
+    if '_ARGS' in sign.parameters:
+        raise ValueError(
+            'The arguments of the function to be decorated with a contract checker include "_ARGS" which is '
+            'a reserved placeholder for positional arguments in the condition.')
+
+    if '_KWARGS' in sign.parameters:
+        raise ValueError(
+            'The arguments of the function to be decorated with a contract checker include "_KWARGS" which is '
+            'a reserved placeholder for keyword arguments in the condition.')
+
     param_names = list(sign.parameters.keys())
 
     # Determine the default argument values.
@@ -339,6 +359,14 @@ def decorate_with_checker(func: CallableT) -> CallableT:
     def wrapper(*args, **kwargs):  # type: ignore
         """Wrap func by checking the preconditions and postconditions."""
         # pylint: disable=too-many-branches
+
+        if '_ARGS' in kwargs:
+            raise TypeError('The arguments of the function call include "_ARGS" which is '
+                            'a placeholder for positional arguments in a condition.')
+
+        if '_KWARGS' in kwargs:
+            raise TypeError('The arguments of the function call include "_KWARGS" which is '
+                            'a placeholder for keyword arguments in a condition.')
 
         # Use try-finally instead of ExitStack for performance.
         try:

--- a/tests/test_args_and_kwargs_in_contract.py
+++ b/tests/test_args_and_kwargs_in_contract.py
@@ -1,0 +1,239 @@
+# pylint: disable=missing-docstring
+# pylint: disable=no-self-use
+# pylint: disable=invalid-name
+# pylint: disable=unused-argument
+# pylint: disable=no-member
+# pylint: disable=unnecessary-lambda
+import copy
+import textwrap
+import unittest
+from typing import Optional, Any, Tuple, Dict
+
+import icontract
+import tests.error
+
+
+class TestArgs(unittest.TestCase):
+    def test_args_without_variable_positional_arguments(self) -> None:
+        recorded_args = None  # type: Optional[Tuple[Any, ...]]
+
+        def set_args(args: Tuple[Any, ...]) -> bool:
+            nonlocal recorded_args
+            recorded_args = copy.copy(args)
+            return True
+
+        @icontract.require(lambda _ARGS: set_args(_ARGS))
+        def some_func(x: int) -> None:
+            pass
+
+        some_func(3)
+
+        assert recorded_args is not None
+        self.assertTupleEqual((3, ), recorded_args)
+
+    def test_args_with_named_and_variable_positional_arguments(self) -> None:
+        recorded_args = None  # type: Optional[Tuple[Any, ...]]
+
+        def set_args(args: Tuple[Any, ...]) -> bool:
+            nonlocal recorded_args
+            recorded_args = copy.copy(args)
+            return True
+
+        @icontract.require(lambda _ARGS: set_args(_ARGS))
+        def some_func(x: int, *args: Any) -> None:
+            pass
+
+        some_func(3, 2)
+
+        assert recorded_args is not None
+        self.assertTupleEqual((3, 2), recorded_args)
+
+    def test_args_with_only_variable_positional_arguments(self) -> None:
+        recorded_args = None  # type: Optional[Tuple[Any, ...]]
+
+        def set_args(args: Tuple[Any, ...]) -> bool:
+            nonlocal recorded_args
+            recorded_args = copy.copy(args)
+            return True
+
+        @icontract.require(lambda _ARGS: set_args(_ARGS))
+        def some_func(*args: Any) -> None:
+            pass
+
+        some_func(3, 2, 1)
+
+        assert recorded_args is not None
+        self.assertTupleEqual((3, 2, 1), recorded_args)
+
+    def test_args_with_uncommon_variable_positional_arguments(self) -> None:
+        recorded_args = None  # type: Optional[Tuple[Any, ...]]
+
+        def set_args(args: Tuple[Any, ...]) -> bool:
+            nonlocal recorded_args
+            recorded_args = copy.copy(args)
+            return True
+
+        @icontract.require(lambda _ARGS: set_args(_ARGS))
+        def some_func(*arguments: Any) -> None:
+            pass
+
+        some_func(3, 2, 1, 0)
+
+        assert recorded_args is not None
+        self.assertTupleEqual((3, 2, 1, 0), recorded_args)
+
+    def test_fail(self) -> None:
+        @icontract.require(lambda _ARGS: len(_ARGS) > 2)
+        def some_func(*args: Any) -> None:
+            pass
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            some_func(3)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        assert violation_error is not None
+        self.assertEqual(
+            textwrap.dedent('''\
+                len(_ARGS) > 2:
+                _ARGS was (3,)
+                len(_ARGS) was 1'''), tests.error.wo_mandatory_location(str(violation_error)))
+
+
+class TestKwargs(unittest.TestCase):
+    def test_kwargs_without_variable_keyword_arguments(self) -> None:
+        recorded_kwargs = None  # type: Optional[Dict[str, Any]]
+
+        def set_kwargs(kwargs: Dict[str, Any]) -> bool:
+            nonlocal recorded_kwargs
+            recorded_kwargs = copy.copy(kwargs)
+            return True
+
+        @icontract.require(lambda _KWARGS: set_kwargs(_KWARGS))
+        def some_func(x: int) -> None:
+            pass
+
+        some_func(x=3)
+
+        assert recorded_kwargs is not None
+        self.assertDictEqual({"x": 3}, recorded_kwargs)
+
+    def test_kwargs_with_named_and_variable_keyword_arguments(self) -> None:
+        recorded_kwargs = None  # type: Optional[Dict[str, Any]]
+
+        def set_kwargs(kwargs: Dict[str, Any]) -> bool:
+            nonlocal recorded_kwargs
+            recorded_kwargs = copy.copy(kwargs)
+            return True
+
+        @icontract.require(lambda _KWARGS: set_kwargs(_KWARGS))
+        def some_func(x: int, **kwargs: Any) -> None:
+            pass
+
+        some_func(x=3, y=2)
+
+        assert recorded_kwargs is not None
+        self.assertDictEqual({"x": 3, "y": 2}, recorded_kwargs)
+
+    def test_kwargs_with_only_variable_keyword_arguments(self) -> None:
+        recorded_kwargs = None  # type: Optional[Dict[str, Any]]
+
+        def set_kwargs(kwargs: Dict[str, Any]) -> bool:
+            nonlocal recorded_kwargs
+            recorded_kwargs = copy.copy(kwargs)
+            return True
+
+        @icontract.require(lambda _KWARGS: set_kwargs(_KWARGS))
+        def some_func(**kwargs: Any) -> None:
+            pass
+
+        some_func(x=3, y=2, z=1)
+
+        assert recorded_kwargs is not None
+        self.assertDictEqual({"x": 3, "y": 2, "z": 1}, recorded_kwargs)
+
+    def test_kwargs_with_uncommon_argument_name_for_variable_keyword_arguments(self) -> None:
+        recorded_kwargs = None  # type: Optional[Dict[str, Any]]
+
+        def set_kwargs(kwargs: Dict[str, Any]) -> bool:
+            nonlocal recorded_kwargs
+            recorded_kwargs = copy.copy(kwargs)
+            return True
+
+        @icontract.require(lambda _KWARGS: set_kwargs(_KWARGS))
+        def some_func(**parameters: Any) -> None:
+            pass
+
+        some_func(x=3, y=2, z=1, a=0)
+
+        assert recorded_kwargs is not None
+        self.assertDictEqual({"x": 3, "y": 2, "z": 1, "a": 0}, recorded_kwargs)
+
+    def test_fail(self) -> None:
+        @icontract.require(lambda _KWARGS: 'x' in _KWARGS)
+        def some_func(**kwargs: Any) -> None:
+            pass
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            some_func(y=3)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        assert violation_error is not None
+        self.assertEqual(
+            textwrap.dedent("'x' in _KWARGS: _KWARGS was {'y': 3}"),
+            tests.error.wo_mandatory_location(str(violation_error)))
+
+
+class TestArgsAndKwargs(unittest.TestCase):
+    def test_that_args_and_kwargs_are_both_passed_as_placeholders(self) -> None:
+        recorded_args = None  # type: Optional[Tuple[Any, ...]]
+        recorded_kwargs = None  # type: Optional[Dict[str, Any]]
+
+        def set_args_and_kwargs(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> bool:
+            nonlocal recorded_args
+            nonlocal recorded_kwargs
+            recorded_args = copy.copy(args)
+            recorded_kwargs = copy.copy(kwargs)
+            return True
+
+        @icontract.require(lambda _ARGS, _KWARGS: set_args_and_kwargs(_ARGS, _KWARGS))
+        def some_func(*args: Any, **kwargs: Any) -> None:
+            pass
+
+        some_func(5, x=10, y=20, z=30)
+
+        assert recorded_args is not None
+        self.assertTupleEqual((5, ), recorded_args)
+
+        assert recorded_kwargs is not None
+        self.assertDictEqual({"x": 10, "y": 20, "z": 30}, recorded_kwargs)
+
+    def test_a_very_mixed_case(self) -> None:
+        recorded_args = None  # type: Optional[Tuple[Any, ...]]
+        recorded_kwargs = None  # type: Optional[Dict[str, Any]]
+
+        def set_args_and_kwargs(args: Tuple[Any, ...], kwargs: Dict[str, Any]) -> bool:
+            nonlocal recorded_args
+            nonlocal recorded_kwargs
+            recorded_args = copy.copy(args)
+            recorded_kwargs = copy.copy(kwargs)
+            return True
+
+        @icontract.require(lambda _ARGS, _KWARGS: set_args_and_kwargs(_ARGS, _KWARGS))
+        def some_func(x: int, y: int, *args: Any, **kwargs: Any) -> None:
+            pass
+
+        some_func(5, 10, 20, z=30)
+
+        assert recorded_args is not None
+        self.assertTupleEqual((5, 10, 20), recorded_args)
+
+        assert recorded_kwargs is not None
+        self.assertDictEqual({"z": 30}, recorded_kwargs)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Certain conditions need to handle variable postiional or keyword
arguments of the function call. Currently, contracts could not refer to
them and thus the functions without explicitly named arguments could not
be decorated.

This patch introduces two special arguments populated by icontract for
the condition function: `_ARGS`, which captures all the positional
arguments in the function call, and `_KWARGS`, which captures the
keyword arguments, respectively.

Fixes #147.