### PR TITLE
Integrated with icontract-hypothesis

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -5,3 +5,18 @@ ignore_missing_imports = True
 
 [mypy-dpcontracts]
 ignore_missing_imports = True
+
+[mypy-icontract_hypothesis]
+ignore_missing_imports = True
+
+[mypy-hypothesis.strategies._internal.types]
+ignore_missing_imports = True
+
+[mypy-hypothesis.strategies._internal]
+ignore_missing_imports = True
+
+[mypy-hypothesis.strategies]
+ignore_missing_imports = True
+
+[mypy-hypothesis]
+ignore_missing_imports = True


### PR DESCRIPTION
This patch integrates with icontract-hypothesis (and consequently
Hypothesis) by registering all DBC classes with Hypothesis.
This is necessary so that precondition considerations are propagated in
Hypothesis build strategies.