### PR TITLE
Bumped to 2.4.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,15 @@
+2.4.0
+=====
+* Integrated with icontract-hypothesis (#179)
+* Refactored for icontract-hypothesis (#178)
+* Added special arguments `_ARGS` and `_KWARGS` (#176)
+* Tested with typeguard (#175)
+* Tested with `dataclasses.dataclass` (#173)
+* Added invariants to namedtuple (#172)
+* Added support for recomputation of f-strings (#170)
+* Exempted `__new__` from invariant checks (#168)
+* Added support for named expressions in contracts (#166)
+
 2.3.7
 =====
 * Acted upon deprecation warning ins ``ast`` module when generating the

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = '2.3.7'
+__version__ = '2.4.0'
 __author__ = 'Marko Ristin'
 __copyright__ = 'Copyright 2019 Parquery AG'
 __license__ = 'MIT'

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(here, 'README.rst'), encoding='utf-8') as fid:
 setup(
     name='icontract',
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version='2.3.7',
+    version='2.4.0',
     description='Provide design-by-contract with informative violation messages.',
     long_description=long_description,
     url='https://github.com/Parquery/icontract',


### PR DESCRIPTION
 Integrated with icontract-hypothesis (#179)
* Refactored for icontract-hypothesis (#178)
* Added special arguments `_ARGS` and `_KWARGS` (#176)
* Tested with typeguard (#175)
* Tested with `dataclasses.dataclass` (#173)
* Added invariants to namedtuple (#172)
* Added support for recomputation of f-strings (#170)
* Exempted `__new__` from invariant checks (#168)
* Added support for named expressions in contracts (#166)