### PR TITLE
Refactored and added tests for integrators

### DIFF
--- a/icontract/_represent.py
+++ b/icontract/_represent.py
@@ -310,9 +310,29 @@ def find_lambda_condition(decorator_inspection: DecoratorInspection) -> Optional
     return ConditionLambdaInspection(atok=decorator_inspection.atok, node=lambda_node)
 
 
+def inspect_lambda_condition(condition: Callable[..., Any]) -> Optional[ConditionLambdaInspection]:
+    """
+    Try to extract the source code of the condition as lambda.
+
+    If the condition is not a lambda, returns None.
+    """
+    if not is_lambda(condition):
+        return None
+
+    lines, condition_lineno = inspect.findsource(condition)
+    filename = inspect.getsourcefile(condition)
+    assert filename is not None
+
+    decorator_inspection = inspect_decorator(lines=lines, lineno=condition_lineno, filename=filename)
+
+    lambda_inspection = find_lambda_condition(decorator_inspection=decorator_inspection)
+
+    return lambda_inspection
+
+
 # yapf: disable
 def collect_variable_lookup(
-        condition: Callable[..., bool],
+        condition: Callable[..., Any],
         condition_kwargs: Optional[Mapping[str, Any]] = None
 ) ->List[Mapping[str, Any]]:
     """

--- a/tests/test_for_integrators.py
+++ b/tests/test_for_integrators.py
@@ -1,0 +1,158 @@
+"""Test logic that can be potentially used by the integrators such as third-party libraries."""
+
+# pylint: disable=protected-access,no-self-use,missing-docstring
+# pylint: disable=invalid-name,unnecessary-lambda,no-member
+
+import ast
+import unittest
+from typing import List, MutableMapping, Any
+
+import icontract._checkers
+import icontract._represent
+
+
+@icontract.require(lambda x: x > 0)
+@icontract.snapshot(lambda cumulative: None if len(cumulative) == 0 else cumulative[-1], "last")
+@icontract.snapshot(lambda cumulative: len(cumulative), "len_cumulative")
+@icontract.ensure(lambda cumulative, OLD: len(cumulative) == OLD.len_cumulative + 1)
+@icontract.ensure(lambda x, cumulative, OLD: OLD.last is None or OLD.last + x == cumulative[-1])
+@icontract.ensure(lambda x, cumulative, OLD: OLD.last is not None or x == cumulative[-1])
+def func_with_contracts(x: int, cumulative: List[int]) -> None:
+    if len(cumulative) == 0:
+        cumulative.append(x)
+    else:
+        cumulative.append(x + cumulative[-1])
+
+
+def func_without_contracts() -> None:
+    pass
+
+
+@icontract.invariant(lambda self: self.x > 0)
+class ClassWithInvariants(icontract.DBC):
+    def __init__(self) -> None:
+        self.x = 1
+
+
+class TestForIntegrators(unittest.TestCase):
+    def test_that_there_is_no_checker_if_no_contracts(self) -> None:
+        checker = icontract._checkers.find_checker(func=func_without_contracts)
+        self.assertIsNone(checker)
+
+    def test_dealing_with_preconditions(self) -> None:
+        checker = icontract._checkers.find_checker(func=func_with_contracts)
+        assert checker is not None
+
+        preconditions = checker.__preconditions__  # type: ignore
+        assert isinstance(preconditions, list)
+        assert all(isinstance(group, list) for group in preconditions)
+        assert all(isinstance(contract, icontract._types.Contract) for group in preconditions for contract in group)
+
+        ##
+        # Evaluate manually preconditions
+        ##
+
+        kwargs = {'x': 4, 'cumulative': [2]}
+
+        success = True
+        # We have to check preconditions in groups in case they are weakened
+        for group in preconditions:
+            success = True
+            for contract in group:
+                condition_kwargs = icontract._checkers.select_condition_kwargs(
+                    contract=contract, resolved_kwargs=kwargs)
+
+                success = contract.condition(**condition_kwargs)
+                if not success:
+                    break
+
+            if success:
+                break
+
+        assert success
+
+    def test_dealing_with_postconditions(self) -> None:
+        checker = icontract._checkers.find_checker(func=func_with_contracts)
+        assert checker is not None
+
+        # Retrieve postconditions
+        postconditions = checker.__postconditions__  # type: ignore
+        assert isinstance(postconditions, list)
+        assert all(isinstance(contract, icontract._types.Contract) for contract in postconditions)
+
+        # Retrieve snapshots
+        snapshots = checker.__postcondition_snapshots__  # type: ignore
+        assert isinstance(snapshots, list)
+        assert all(isinstance(snapshot, icontract._types.Snapshot) for snapshot in snapshots)
+
+        ##
+        # Evaluate manually postconditions
+        ##
+
+        cumulative = [2]
+        kwargs = {'x': 4, 'cumulative': cumulative}  # kwargs **before** the call
+
+        # Capture OLD
+        old_as_mapping = dict()  # type: MutableMapping[str, Any]
+        for snap in snapshots:
+            snap_kwargs = icontract._checkers.select_capture_kwargs(a_snapshot=snap, resolved_kwargs=kwargs)
+
+            old_as_mapping[snap.name] = snap.capture(**snap_kwargs)
+
+        old = icontract._checkers.Old(mapping=old_as_mapping)
+
+        # Simulate the call
+        cumulative.append(6)
+
+        # Evaluate the postconditions
+        kwargs['OLD'] = old
+
+        success = True
+        for contract in postconditions:
+            condition_kwargs = icontract._checkers.select_condition_kwargs(contract=contract, resolved_kwargs=kwargs)
+
+            success = contract.condition(**condition_kwargs)
+
+            if not success:
+                break
+
+        assert success
+
+    def test_dealing_with_invariants(self) -> None:
+        instance = ClassWithInvariants()
+        assert instance.x == 1  # Test assumption
+
+        invariants = ClassWithInvariants.__invariants__  # type: ignore
+        assert isinstance(invariants, list)
+        assert all(isinstance(invariant, icontract._types.Contract) for invariant in invariants)
+
+        invariants = instance.__invariants__  # type: ignore
+        assert isinstance(invariants, list)
+        assert all(isinstance(invariant, icontract._types.Contract) for invariant in invariants)
+
+        success = True
+        for contract in invariants:
+            success = contract.condition(self=instance)
+
+            if not success:
+                break
+
+        assert success
+
+    def test_condition_text(self) -> None:
+        checker = icontract._checkers.find_checker(func=func_with_contracts)
+        assert checker is not None
+
+        # Retrieve postconditions
+        contract = checker.__postconditions__[0]  # type: ignore
+        assert isinstance(contract, icontract._types.Contract)
+
+        assert icontract._represent.is_lambda(a_function=contract.condition)
+
+        lambda_inspection = icontract._represent.inspect_lambda_condition(condition=contract.condition)
+
+        assert lambda_inspection is not None
+
+        self.assertEqual('OLD.last is not None or x == cumulative[-1]', lambda_inspection.text)
+
+        assert isinstance(lambda_inspection.node, ast.Lambda)


### PR DESCRIPTION
This patch introduces a test suite meant to document what downstream
integrators (such as static validators, documentation tools *etc.*)
should use.

The patch also includes a refactoring so that the interface is more
ergonomic to use.