### PR TITLE
Bumped to 2.4.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.4.1
+=====
+*  Removed automatic registration with Hypothesis and replaced it with a hook that
+   downstream libraries such as icontract-hypothesis can use (#181)
+* Refactored and added tests for integrators (#182)
+
 2.4.0
 =====
 * Integrated with icontract-hypothesis (#179)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = '2.4.0'
+__version__ = '2.4.1'
 __author__ = 'Marko Ristin'
 __copyright__ = 'Copyright 2019 Parquery AG'
 __license__ = 'MIT'


### PR DESCRIPTION
*  Removed automatic registration with Hypothesis and replaced it
   with a hook that downstream libraries such as icontract-hypothesis
   can use (#181)
* Refactored and added tests for integrators (#182)