### PR TITLE
Added support for async

### DIFF
--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -1,0 +1,52 @@
+Async
+=====
+
+Icontract supports both adding sync contracts to *async functions* as well as enforcing *async conditions* (and
+capturing *async snapshots*).
+
+You simply define your conditions as decorators of an async function:
+
+.. code-block:: python
+
+    import icontract
+
+    @icontract.require(lambda x: x > 0)
+    @icontract.ensure(lambda x, result: x < result)
+    async def do_something(x: int) -> int:
+        ...
+
+
+Limitations
+-----------
+**Async conditions**.
+If you want to enforce async conditions, the function also needs to be defined as async:
+
+.. code-block:: python
+
+    import icontract
+
+    async def has_author(author_id: str) -> bool:
+        ...
+
+    @icontract.ensure(has_author)
+    async def upsert_author(name: str) -> str:
+        ...
+
+It is not possible to add an async condition to a sync function.
+Doing so will raise a ``ValueError`` at runtime.
+The reason behind this limitation is that the wrapper around the function would need to be made async, which would
+break the code calling the original function and expecting it to be synchronous.
+
+**Invariants**.
+As invariants need to wrap dunder methods, including ``__init__``, their conditions *can not* be
+async, as most dunder methods need to be synchronous methods, and wrapping them with async code would
+break that constraint.
+You can, of course, use synchronous invariants on *async* method functions without problems.
+
+**No async lambda**.
+Another practical limitation is that Python does not support async lambda (see `this Python issue`_),
+so defining async conditions (and snapshots) is indeed tedious.
+Please consider asking for async lambdas on `python-ideas mailing list`_ to give the issue some visibility.
+
+.. _this Python issue: https://bugs.python.org/issue33447
+.. _python-ideas mailing list: https://mail.python.org/mailman3/lists/python-ideas.python.org/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -8,6 +8,7 @@ Welcome to icontract's documentation!
    introduction
    usage
    checking_types_at_runtime
+   async
    implementation_details
    known_issues
    benchmarks

--- a/icontract/_represent.py
+++ b/icontract/_represent.py
@@ -193,7 +193,7 @@ class ConditionLambdaInspection:
 
 
 _DECORATOR_RE = re.compile(r'^\s*@[a-zA-Z_]')
-_DEF_CLASS_RE = re.compile(r'^\s*(def |class )')
+_DEF_CLASS_RE = re.compile(r'^\s*(async\s+def|def |class )')
 
 
 class DecoratorInspection:

--- a/tests/test_postcondition.py
+++ b/tests/test_postcondition.py
@@ -457,7 +457,7 @@ class TestInvalid(unittest.TestCase):
             type_err = err
 
         self.assertIsNotNone(type_err)
-        self.assertEqual("The argument(s) of the postcondition have not been set: ['b']. "
+        self.assertEqual("The argument(s) of the contract condition have not been set: ['b']. "
                          "Does the original function define them? Did you supply them in the call?",
                          tests.error.wo_mandatory_location(str(type_err)))
 
@@ -503,7 +503,7 @@ class TestInvalid(unittest.TestCase):
             type_error = err
 
         self.assertIsNotNone(type_error)
-        self.assertEqual("The argument(s) of the postcondition error have not been set: ['z']. "
+        self.assertEqual("The argument(s) of the contract error have not been set: ['z']. "
                          "Does the original function define them? Did you supply them in the call?",
                          tests.error.wo_mandatory_location(str(type_error)))
 

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -491,7 +491,7 @@ class TestInvalid(unittest.TestCase):
             type_err = err
 
         self.assertIsNotNone(type_err)
-        self.assertEqual("The argument(s) of the precondition have not been set: ['b']. "
+        self.assertEqual("The argument(s) of the contract condition have not been set: ['b']. "
                          "Does the original function define them? Did you supply them in the call?",
                          tests.error.wo_mandatory_location(str(type_err)))
 
@@ -507,7 +507,7 @@ class TestInvalid(unittest.TestCase):
             type_error = err
 
         self.assertIsNotNone(type_error)
-        self.assertEqual("The argument(s) of the precondition error have not been set: ['z']. "
+        self.assertEqual("The argument(s) of the contract error have not been set: ['z']. "
                          "Does the original function define them? Did you supply them in the call?",
                          tests.error.wo_mandatory_location(str(type_error)))
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -128,7 +128,7 @@ class TestInvalid(unittest.TestCase):
             type_error = err
 
         self.assertIsNotNone(type_error)
-        self.assertEqual("The argument(s) of the postcondition have not been set: ['OLD']. "
+        self.assertEqual("The argument(s) of the contract condition have not been set: ['OLD']. "
                          "Does the original function define them? Did you supply them in the call? "
                          "Did you decorate the function with a snapshot to capture OLD values?",
                          tests.error.wo_mandatory_location(str(type_error)))

--- a/tests_3_8/test_async.py
+++ b/tests_3_8/test_async.py
@@ -1,0 +1,258 @@
+# The module ``unittest`` supports async only from 3.8 on.
+# That is why we had to move this test to 3.8 specific tests.
+
+# pylint: disable=missing-docstring, invalid-name, no-member
+
+import unittest
+from typing import Optional, List
+
+import icontract
+import tests.error
+
+
+class TestAsyncFunctionSyncPrecondition(unittest.IsolatedAsyncioTestCase):
+    async def test_ok(self) -> None:
+        @icontract.require(lambda x: x > 0)
+        async def some_func(x: int) -> int:
+            return x * 10
+
+        result = await some_func(1)
+        self.assertEqual(10, result)
+
+    async def test_fail(self) -> None:
+        @icontract.require(lambda x: x > 0)
+        async def some_func(x: int) -> int:
+            return x * 10
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            _ = await some_func(-1)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual("x > 0: x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+
+
+class TestAsyncFunctionSyncPostcondition(unittest.IsolatedAsyncioTestCase):
+    async def test_ok(self) -> None:
+        @icontract.ensure(lambda result: result > 0)
+        async def some_func() -> int:
+            return 100
+
+        result = await some_func()
+        self.assertEqual(100, result)
+
+    async def test_fail(self) -> None:
+        @icontract.ensure(lambda result: result > 0)
+        async def some_func() -> int:
+            return -100
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            _ = await some_func()
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual("result > 0: result was -100", tests.error.wo_mandatory_location(str(violation_error)))
+
+
+class TestAsyncMethodAndInvariant(unittest.IsolatedAsyncioTestCase):
+    async def test_ok(self) -> None:
+        @icontract.invariant(lambda self: self.x > 0)
+        class A:
+            def __init__(self) -> None:
+                self.x = 100
+
+            async def some_func(self) -> int:
+                self.x = 200
+                return self.x
+
+            def another_func(self) -> int:
+                self.x = 300
+                return self.x
+
+        a = A()
+        result = await a.some_func()
+        self.assertEqual(200, result)
+
+        result = a.another_func()
+        self.assertEqual(300, result)
+
+    async def test_fail(self) -> None:
+        @icontract.invariant(lambda self: self.x > 0)
+        class A:
+            def __init__(self) -> None:
+                self.x = 100
+
+            async def some_func(self) -> None:
+                self.x = -1
+
+        a = A()
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            await a.some_func()
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertTrue(tests.error.wo_mandatory_location(str(violation_error)).startswith('self.x > 0'))
+
+
+class TestAsyncFunctionAsyncPrecondition(unittest.IsolatedAsyncioTestCase):
+    async def test_ok(self) -> None:
+        async def x_greater_zero(x: int) -> bool:
+            return x > 0
+
+        @icontract.require(x_greater_zero)
+        async def some_func(x: int) -> int:
+            return x * 10
+
+        result = await some_func(1)
+        self.assertEqual(10, result)
+
+    async def test_fail(self) -> None:
+        async def x_greater_zero(x: int) -> bool:
+            return x > 0
+
+        @icontract.require(x_greater_zero)
+        async def some_func(x: int) -> int:
+            return x * 10
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            _ = await some_func(-1)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual("x_greater_zero: x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+
+
+class TestAsyncFunctionAsyncPostcondition(unittest.IsolatedAsyncioTestCase):
+    async def test_ok(self) -> None:
+        async def result_greater_zero(result: int) -> bool:
+            return result > 0
+
+        @icontract.ensure(result_greater_zero)
+        async def some_func() -> int:
+            return 100
+
+        result = await some_func()
+        self.assertEqual(100, result)
+
+    async def test_snapshot(self) -> None:
+        async def capture_len_lst(lst: List[int]) -> int:
+            return len(lst)
+
+        @icontract.snapshot(capture_len_lst, name="len_lst")
+        @icontract.ensure(lambda OLD, lst: OLD.len_lst + 1 == len(lst))
+        async def some_func(lst: List[int]) -> None:
+            lst.append(1984)
+
+        lst = []  # type: List[int]
+        await some_func(lst=lst)
+        self.assertListEqual([1984], lst)
+
+    async def test_fail(self) -> None:
+        async def result_greater_zero(result: int) -> bool:
+            return result > 0
+
+        @icontract.ensure(result_greater_zero)
+        async def some_func() -> int:
+            return -100
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            _ = await some_func()
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual("result_greater_zero: result was -100", tests.error.wo_mandatory_location(
+            str(violation_error)))
+
+
+class TestSyncFunction(unittest.IsolatedAsyncioTestCase):
+    def test_that_async_precondition_fails(self) -> None:
+        async def x_greater_zero(x: int) -> bool:
+            return x > 0
+
+        @icontract.require(x_greater_zero)
+        def some_func(x: int) -> int:
+            return x * 10
+
+        value_error = None  # type: Optional[ValueError]
+        try:
+            _ = some_func(100)
+        except ValueError as err:
+            value_error = err
+
+        self.assertIsNotNone(value_error)
+        self.assertRegex(
+            str(value_error),
+            r'^Unexpected coroutine \(async\) condition <.*> for a sync function <.*\.some_func at .*>.')
+
+    def test_that_async_postcondition_fails(self) -> None:
+        async def result_greater_zero(result: int) -> bool:
+            return result > 0
+
+        @icontract.ensure(result_greater_zero)
+        def some_func() -> int:
+            return 100
+
+        value_error = None  # type: Optional[ValueError]
+        try:
+            _ = some_func()
+        except ValueError as err:
+            value_error = err
+
+        self.assertIsNotNone(value_error)
+        self.assertRegex(
+            str(value_error),
+            r'^Unexpected coroutine \(async\) condition <.*> for a sync function <.*\.some_func at .*>.')
+
+    def test_that_async_snapshot_fails(self) -> None:
+        async def capture_len_lst(lst: List[int]) -> int:
+            return len(lst)
+
+        @icontract.snapshot(capture_len_lst, name="len_lst")
+        @icontract.ensure(lambda OLD, lst: OLD.len_lst + 1 == len(lst))
+        def some_func(lst: List[int]) -> None:
+            lst.append(1984)
+
+        value_error = None  # type: Optional[ValueError]
+        try:
+            some_func([1])
+        except ValueError as err:
+            value_error = err
+
+        self.assertIsNotNone(value_error)
+        self.assertRegex(
+            str(value_error), r'^Unexpected coroutine \(async\) snapshot capture <function .*\.capture_len_lst at .*> '
+            r'for a sync function <function .*\.some_func at .*>\.')
+
+
+class TestAsyncInvariantsFail(unittest.IsolatedAsyncioTestCase):
+    def test_that_async_invariants_reported(self) -> None:
+        async def some_async_invariant(self: 'A') -> bool:
+            return self.x > 0
+
+        value_error = None  # type: Optional[ValueError]
+        try:
+            # pylint: disable=unused-variable
+            @icontract.invariant(some_async_invariant)
+            class A:
+                def __init__(self) -> None:
+                    self.x = 100
+        except ValueError as error:
+            value_error = error
+
+        self.assertEqual(
+            "Async conditions are not possible in invariants as sync methods such as __init__ have to be wrapped.",
+            str(value_error))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This patch introduces the support for both async functions (as
decoratees) and for async conditions (and snapshots).

This is important for downstream libraries such as [fastapi-icontract]
that are make heavy use of async functions.

[fastapi-icontract]: https://github.com/mristin/fastapi-icontract/