### PR TITLE
Added support for coroutine

### DIFF
--- a/docs/source/async.rst
+++ b/docs/source/async.rst
@@ -1,10 +1,12 @@
 Async
 =====
 
-Icontract supports both adding sync contracts to *async functions* as well as enforcing *async conditions* (and
-capturing *async snapshots*).
+Icontract supports both adding sync contracts to `coroutine functions <coroutine function_>`_ as well as enforcing
+*async conditions* (and capturing *async snapshots*).
 
-You simply define your conditions as decorators of an async function:
+.. _coroutine function: https://docs.python.org/3/glossary.html#term-coroutine-function
+
+You simply define your conditions as decorators of a `coroutine function`_:
 
 .. code-block:: python
 
@@ -16,8 +18,8 @@ You simply define your conditions as decorators of an async function:
         ...
 
 
-Limitations
------------
+Special Considerations
+----------------------
 **Async conditions**.
 If you want to enforce async conditions, the function also needs to be defined as async:
 
@@ -33,7 +35,7 @@ If you want to enforce async conditions, the function also needs to be defined a
         ...
 
 It is not possible to add an async condition to a sync function.
-Doing so will raise a ``ValueError`` at runtime.
+Doing so will raise a `ValueError`_ at runtime.
 The reason behind this limitation is that the wrapper around the function would need to be made async, which would
 break the code calling the original function and expecting it to be synchronous.
 
@@ -43,10 +45,95 @@ async, as most dunder methods need to be synchronous methods, and wrapping them 
 break that constraint.
 You can, of course, use synchronous invariants on *async* method functions without problems.
 
+.. _no-async-lambda limitation:
+
 **No async lambda**.
 Another practical limitation is that Python does not support async lambda (see `this Python issue`_),
-so defining async conditions (and snapshots) is indeed tedious.
+so defining async conditions (and snapshots) is indeed tedious (see the
+:ref:`next section <coroutine as condition result>`).
 Please consider asking for async lambdas on `python-ideas mailing list`_ to give the issue some visibility.
 
 .. _this Python issue: https://bugs.python.org/issue33447
 .. _python-ideas mailing list: https://mail.python.org/mailman3/lists/python-ideas.python.org/
+
+.. _coroutine as condition result:
+
+**Coroutine as condition result**.
+If the condition returns a `coroutine`_, the `coroutine`_ will be awaited before it is evaluated for truthiness.
+
+This means in practice that you can work around :ref:`no-async-lambda limitation` applying coroutine functions
+on your condition arguments (which in turn makes the condition result in a `coroutine`_).
+
+.. _coroutine: https://docs.python.org/3/glossary.html#term-coroutine
+
+For example:
+
+.. code-block:: python
+
+        async def some_condition(a: float, b: float) -> bool:
+            ...
+
+        @icontract.require(lambda x: some_condition(a=x, b=x**2))
+        async def some_func(x: float) -> None:
+            ...
+
+A big fraction of contracts on sequences require an `all`_ operation to check that all the item of a sequence are
+``True``.
+Unfortunately, `all`_ does not automatically operate on a sequence of `Awaitables <awaitable_>`_,
+but you can introduce a short helper function as a substitute:
+
+.. _all: https://docs.python.org/3/library/functions.html#all
+.. _awaitable: https://docs.python.org/3/library/asyncio-task.html#awaitables
+
+.. code-block:: python
+
+    T = TypeVar('T')
+
+    async def awaited_all(aws: Iterable[Awaitable[T]]) -> bool:
+        for awaitable in aws:
+            if not await awaitable:
+                return False
+
+        return True
+
+Here is a practical example that uses ``awaited_all``:
+
+.. code-block:: python
+
+    async def has_author(identifier: str) -> bool:
+        ...
+
+    async def has_category(category: str) -> bool:
+        ...
+
+    @dataclasses.dataclass
+    class Book:
+        identifier: str
+        author: str
+
+    @icontract.require(lambda categories: awaited_all(map(has_category, categories)))
+    @icontract.ensure(lambda result: awaited_all(has_author(book.author) for book in result))
+    async def list_books(categories: List[str]) -> List[Book]:
+        ...
+
+**Coroutines have side effects.**
+If the condition of a contract returns a `coroutine`_, the condition can not be
+re-computed upon the violation to produce an informative violation message.
+This means that you need to :ref:`specify an explicit error <custom-errors>` which should be raised
+on contract violation.
+
+For example:
+
+.. code-block:: python
+
+    async def some_condition() -> bool:
+        ...
+
+    @icontract.require(
+        lambda: some_condition(),
+        error=lambda: icontract.ViolationError("Something went wrong."))
+
+If you do not specify the error, and the condition returns a `coroutine`_, the decorator will raise a
+`ValueError`_ at re-computation time.
+
+.. _ValueError: https://docs.python.org/3/library/exceptions.html#ValueError

--- a/icontract/_decorators.py
+++ b/icontract/_decorators.py
@@ -29,6 +29,9 @@ class require:  # pylint: disable=invalid-name
         Initialize.
 
         :param condition: precondition predicate
+
+            If the condition returns a coroutine, you must specify the `error` as
+            coroutines have side effects and can not be recomputed.
         :param description: textual description of the precondition
         :param a_repr: representation instance that defines how the values are represented
         :param enabled:
@@ -203,7 +206,11 @@ class ensure:  # pylint: disable=invalid-name
         """
         Initialize.
 
-        :param condition: postcondition predicate
+        :param condition:
+            postcondition predicate.
+
+            If the condition returns a coroutine, you must specify the `error` as
+            coroutines have side effects and can not be recomputed.
         :param description: textual description of the postcondition
         :param a_repr: representation instance that defines how the values are represented
         :param enabled:
@@ -296,7 +303,11 @@ class invariant:  # pylint: disable=invalid-name
         """
         Initialize a class decorator to establish the invariant on all the public methods.
 
-        :param condition: invariant predicate
+        :param condition:
+            invariant predicate.
+
+            The condition must not be a coroutine function as dunder functions (including ``__init__``)
+            of a class can not be async.
         :param description: textual description of the invariant
         :param a_repr: representation instance that defines how the values are represented
         :param enabled:


### PR DESCRIPTION
Previously, we expected the condition to always return a materialized
check. This patch allows the condition to return a coroutine so that it
is awaited before the value is evaluated.

This allows the user to specify conditions that work around the lack of
async lambda in the language.