### PR TITLE
Fixed mypy on typeguard unit test

### DIFF
--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -40,7 +40,7 @@ class TestPrecondition(unittest.TestCase):
         b = B()
         type_error = None  # type: Optional[TypeError]
         try:
-            some_func(b)
+            some_func(b)  # type: ignore
         except TypeError as err:
             type_error = err
 


### PR DESCRIPTION
This patch forces mypy to ignore a line where we explicitly introduce an
error to test that the icontract plays well with the typeguard library.