### PR TITLE
Added support for error-as-instance

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -537,7 +537,6 @@ by supplying ``error`` argument to the decorator.
 
 The ``error`` argument can either be:
 
-* **An exception class.** The exception is constructed with the violation message and finally raised.
 * **A callable that returns an exception.** The callable accepts the subset of arguments of the original function
   (including ``result`` and ``OLD`` for postconditions) or ``self`` in case of invariants, respectively,
   and returns an exception. The arguments to the condition function can freely differ from the arguments
@@ -549,22 +548,10 @@ The ``error`` argument can either be:
   be parsed. Hence, violation of contracts with ``error`` arguments as callables incur a much smaller computational
   overhead in case of violations compared to contracts with default violation messages for which we need to  trace
   the argument values and parse the condition function.
+* **A subclass of `BaseException`_.** The exception is constructed with the violation message and finally raised.
+* **An instance of `BaseException`_.** The exception is raised as-is on contract violation.
 
-Here is an example of the error given as an exception class:
-
-.. code-block:: python
-
-    >>> @icontract.require(lambda x: x > 0, error=ValueError)
-    ... def some_func(x: int) -> int:
-    ...     return 123
-    ...
-
-    # Custom Exception class
-    >>> some_func(x=0)
-    Traceback (most recent call last):
-        ...
-    ValueError: File <doctest usage.rst[60]>, line 1 in <module>:
-    x > 0: x was 0
+.. _BaseException: https://docs.python.org/3/library/exceptions.html#BaseException
 
 Here is an example of the error given as a callable:
 
@@ -582,6 +569,39 @@ Here is an example of the error given as a callable:
     Traceback (most recent call last):
         ...
     ValueError: x must be positive, got: 0
+
+
+Here is an example of the error given as a subclass of `BaseException`_:
+
+.. code-block:: python
+
+    >>> @icontract.require(lambda x: x > 0, error=ValueError)
+    ... def some_func(x: int) -> int:
+    ...     return 123
+    ...
+
+    # Custom Exception class
+    >>> some_func(x=0)
+    Traceback (most recent call last):
+        ...
+    ValueError: File <doctest usage.rst[62]>, line 1 in <module>:
+    x > 0: x was 0
+
+Here is an example of the error given as an instance of a `BaseException`_:
+
+.. code-block:: python
+
+    >>> @icontract.require(lambda x: x > 0, error=ValueError("x non-positive"))
+    ... def some_func(x: int) -> int:
+    ...     return 123
+    ...
+
+    # Custom Exception class
+    >>> some_func(x=0)
+    Traceback (most recent call last):
+        ...
+    ValueError: x non-positive
+
 
 .. danger::
     Be careful when you write contracts with custom errors. This might lead the caller to (ab)use the contracts as

--- a/icontract/_decorators.py
+++ b/icontract/_decorators.py
@@ -24,7 +24,7 @@ class require:  # pylint: disable=invalid-name
                  description: Optional[str] = None,
                  a_repr: reprlib.Repr = icontract._globals.aRepr,
                  enabled: bool = __debug__,
-                 error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT]]] = None) -> None:
+                 error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT], BaseException]] = None) -> None:
         """
         Initialize.
 
@@ -42,12 +42,13 @@ class require:  # pylint: disable=invalid-name
             The default is to always check the condition unless the interpreter runs in optimized mode (``-O`` or
             ``-OO``).
         :param error:
-            if given as a callable, ``error`` is expected to accept a subset of function arguments
-            (*e.g.*, also including ``result`` for perconditions, only ``self`` for invariants *etc.*) and return
-            an exception. The ``error`` is called on contract violation and the resulting exception is raised.
+            The error is expected to denote either:
 
-            Otherwise, it is expected to denote an Exception class which is instantiated with the violation message
-            and raised on contract violation.
+            * A callable. ``error`` is expected to accept a subset of function arguments and return an exception.
+              The ``error`` is called on contract violation and the resulting exception is raised.
+            * A subclass of ``BaseException`` which is instantiated with the violation message and raised
+              on contract violation.
+            * An instance of ``BaseException`` that will be raised with the traceback on contract violation.
 
         """
         # pylint: disable=too-many-arguments
@@ -57,9 +58,17 @@ class require:  # pylint: disable=invalid-name
         if not enabled:
             return
 
-        if isinstance(error, type) and not issubclass(error, BaseException):
-            raise ValueError(("The error of the contract is given as a type, "
-                              "but the type does not inherit from BaseException: {}").format(error))
+        if error is None:
+            pass
+        elif isinstance(error, type):
+            if not issubclass(error, BaseException):
+                raise ValueError(("The error of the contract is given as a type, "
+                                  "but the type does not inherit from BaseException: {}").format(error))
+        else:
+            if not inspect.isfunction(error) and not inspect.ismethod(error) and not isinstance(error, BaseException):
+                raise ValueError(
+                    ("The error of the contract must be either a callable (a function or a method), "
+                     "a class (subclass of BaseException) or an instance of BaseException, but got: {}").format(error))
 
         location = None  # type: Optional[str]
         tb_stack = traceback.extract_stack(limit=2)[:1]
@@ -206,7 +215,7 @@ class ensure:  # pylint: disable=invalid-name
                  description: Optional[str] = None,
                  a_repr: reprlib.Repr = icontract._globals.aRepr,
                  enabled: bool = __debug__,
-                 error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT]]] = None) -> None:
+                 error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT], BaseException]] = None) -> None:
         """
         Initialize.
 
@@ -225,13 +234,13 @@ class ensure:  # pylint: disable=invalid-name
             The default is to always check the condition unless the interpreter runs in optimized mode (``-O`` or
             ``-OO``).
         :param error:
-            if given as a callable, ``error`` is expected to accept a subset of function arguments
-            (*e.g.*, also including ``result`` for perconditions, only ``self`` for invariants *etc.*) and return
-            an exception. The ``error`` is called on contract violation and the resulting exception is raised.
+            The error is expected to denote either:
 
-            Otherwise, it is expected to denote an Exception class which is instantiated with the violation message
-            and raised on contract violation.
-
+            * A callable. ``error`` is expected to accept a subset of function arguments and return an exception.
+              The ``error`` is called on contract violation and the resulting exception is raised.
+            * A subclass of ``BaseException`` which is instantiated with the violation message and raised
+              on contract violation.
+            * An instance of ``BaseException`` that will be raised with the traceback on contract violation.
         """
         # pylint: disable=too-many-arguments
         self.enabled = enabled
@@ -240,9 +249,17 @@ class ensure:  # pylint: disable=invalid-name
         if not enabled:
             return
 
-        if isinstance(error, type) and not issubclass(error, BaseException):
-            raise ValueError(("The error of the contract is given as a type, "
-                              "but the type does not inherit from BaseException: {}").format(error))
+        if error is None:
+            pass
+        elif isinstance(error, type):
+            if not issubclass(error, BaseException):
+                raise ValueError(("The error of the contract is given as a type, "
+                                  "but the type does not inherit from BaseException: {}").format(error))
+        else:
+            if not inspect.isfunction(error) and not inspect.ismethod(error) and not isinstance(error, BaseException):
+                raise ValueError(
+                    ("The error of the contract must be either a callable (a function or a method), "
+                     "a class (subclass of BaseException) or an instance of BaseException, but got: {}").format(error))
 
         location = None  # type: Optional[str]
         tb_stack = traceback.extract_stack(limit=2)[:1]
@@ -307,7 +324,7 @@ class invariant:  # pylint: disable=invalid-name
                  description: Optional[str] = None,
                  a_repr: reprlib.Repr = icontract._globals.aRepr,
                  enabled: bool = __debug__,
-                 error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT]]] = None) -> None:
+                 error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT], BaseException]] = None) -> None:
         """
         Initialize a class decorator to establish the invariant on all the public methods.
 
@@ -326,12 +343,13 @@ class invariant:  # pylint: disable=invalid-name
                 The default is to always check the condition unless the interpreter runs in optimized mode (``-O`` or
                 ``-OO``).
         :param error:
-            if given as a callable, ``error`` is expected to accept a subset of function arguments
-            (*e.g.*, also including ``result`` for perconditions, only ``self`` for invariants *etc.*) and return
-            an exception. The ``error`` is called on contract violation and the resulting exception is raised.
+            The error is expected to denote either:
 
-            Otherwise, it is expected to denote an Exception class which is instantiated with the violation message
-            and raised on contract violation.
+            * A callable. ``error`` is expected to accept a subset of function arguments and return an exception.
+              The ``error`` is called on contract violation and the resulting exception is raised.
+            * A subclass of ``BaseException`` which is instantiated with the violation message and raised
+              on contract violation.
+            * An instance of ``BaseException`` that will be raised with the traceback on contract violation.
         :return:
 
         """
@@ -342,9 +360,17 @@ class invariant:  # pylint: disable=invalid-name
         if not enabled:
             return
 
-        if isinstance(error, type) and not issubclass(error, BaseException):
-            raise ValueError(("The error of the contract is given as a type, "
-                              "but the type does not inherit from BaseException: {}").format(error))
+        if error is None:
+            pass
+        elif isinstance(error, type):
+            if not issubclass(error, BaseException):
+                raise ValueError(("The error of the contract is given as a type, "
+                                  "but the type does not inherit from BaseException: {}").format(error))
+        else:
+            if not inspect.isfunction(error) and not inspect.ismethod(error) and not isinstance(error, BaseException):
+                raise ValueError(
+                    ("The error of the contract must be either a callable (a function or a method), "
+                     "a class (subclass of BaseException) or an instance of BaseException, but got: {}").format(error))
 
         location = None  # type: Optional[str]
         tb_stack = traceback.extract_stack(limit=2)[:1]

--- a/icontract/_types.py
+++ b/icontract/_types.py
@@ -1,7 +1,7 @@
 """Define data structures shared among the modules."""
 import inspect
 import reprlib
-from typing import Callable, Optional, Union, Set, List, Any, Type  # pylint: disable=unused-import
+from typing import Callable, Optional, Union, Set, List, Any, Type, cast  # pylint: disable=unused-import
 
 import icontract._globals
 
@@ -19,7 +19,7 @@ class Contract:
                  condition: Callable[..., bool],
                  description: Optional[str] = None,
                  a_repr: reprlib.Repr = icontract._globals.aRepr,
-                 error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT]]] = None,
+                 error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT], BaseException]] = None,
                  location: Optional[str] = None) -> None:
         """
         Initialize.
@@ -57,7 +57,8 @@ class Contract:
         self.error_args = None  # type: Optional[List[str]]
         self.error_arg_set = None  # type: Optional[Set[str]]
         if error is not None and (inspect.isfunction(error) or inspect.ismethod(error)):
-            self.error_args = list(inspect.signature(error).parameters.keys())
+            error_as_callable = cast(Callable[..., ExceptionT], error)
+            self.error_args = list(inspect.signature(error_as_callable).parameters.keys())
             self.error_arg_set = set(self.error_args)
 
         self.location = location

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     extras_require={
         'dev': [
             # yapf: disable
-            'mypy==0.790',
+            'mypy==0.812',
             'pylint==2.3.1',
             'yapf==0.20.2',
             'tox>=3.0.0',


### PR DESCRIPTION
This patch allows the user to supply error as an instance of
``BaseException``. This is practical for cases where the error is fixed
and need not be re-instantiated on every violation.

An additional benefit is that the syntax is a bit shorter than with a
argument-less callable (one `lambda: ` less).