### PR TITLE
Encapsulate adding contracts for integrators

### DIFF
--- a/icontract/_types.py
+++ b/icontract/_types.py
@@ -16,7 +16,7 @@ class Contract:
     # pylint: disable=too-many-instance-attributes
 
     def __init__(self,
-                 condition: Callable[..., bool],
+                 condition: Callable[..., Any],
                  description: Optional[str] = None,
                  a_repr: reprlib.Repr = icontract._globals.aRepr,
                  error: Optional[Union[Callable[..., ExceptionT], Type[ExceptionT], BaseException]] = None,


### PR DESCRIPTION
This patch introduces a mechanism for downstream integrators to add
manually contracts and snapshots to the function checker.