### PR TITLE
Added better reporting on recompute failure

### DIFF
--- a/icontract/_recompute.py
+++ b/icontract/_recompute.py
@@ -311,6 +311,9 @@ class Visitor(ast.NodeVisitor):
         """Visit the function and the arguments and finally make the function call with them."""
         func = self.visit(node=node.func)
 
+        if not callable(func):
+            raise ValueError(("Unexpected call to a non-callle during the re-computation: {}").format(func))
+
         if inspect.iscoroutinefunction(func):
             raise ValueError(
                 ("Unexpected coroutine function {} as a condition of a contract. "

--- a/tests/test_for_integrators.py
+++ b/tests/test_for_integrators.py
@@ -223,3 +223,18 @@ class TestRepresentation(unittest.TestCase):
         self.assertEqual('OLD.last is not None or x == cumulative[-1]', lambda_inspection.text)
 
         assert isinstance(lambda_inspection.node, ast.Lambda)
+
+    def test_condition_representation(self) -> None:
+        checker = icontract._checkers.find_checker(func=func_with_contracts)
+        assert checker is not None
+
+        # Retrieve postconditions
+        contract = checker.__postconditions__[0]  # type: ignore
+        assert isinstance(contract, icontract._types.Contract)
+
+        text = icontract._represent.represent_condition(contract.condition)
+        self.assertEqual('lambda x, cumulative, OLD: OLD.last is not None or x == cumulative[-1]', text)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_3_8/async/test_postcondition.py
+++ b/tests_3_8/async/test_postcondition.py
@@ -119,7 +119,7 @@ class TestCoroutine(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(violation_error)
         self.assertEqual("hihi", str(violation_error))
 
-    async def test_reported_if_without_error(self) -> None:
+    async def test_reported_if_no_error_is_specified_as_we_can_not_recompute_coroutine_functions(self) -> None:
         async def some_condition() -> bool:
             return False
 
@@ -127,13 +127,18 @@ class TestCoroutine(unittest.IsolatedAsyncioTestCase):
         async def some_func() -> None:
             pass
 
-        value_error = None  # type: Optional[ValueError]
+        runtime_error = None  # type: Optional[RuntimeError]
         try:
             await some_func()
-        except ValueError as err:
-            value_error = err
+        except RuntimeError as err:
+            runtime_error = err
 
-        self.assertIsNotNone(value_error)
+        assert runtime_error is not None
+        assert runtime_error.__cause__ is not None
+        assert isinstance(runtime_error.__cause__, ValueError)
+
+        value_error = runtime_error.__cause__
+
         self.assertRegex(
             str(value_error), r"^Unexpected coroutine function <function .*> as a condition of a contract\. "
             r"You must specify your own error if the condition of your contract is a coroutine function\.")

--- a/tests_3_8/async/test_precondition.py
+++ b/tests_3_8/async/test_precondition.py
@@ -93,7 +93,7 @@ class TestCoroutine(unittest.IsolatedAsyncioTestCase):
         self.assertIsNotNone(violation_error)
         self.assertEqual("hihi", str(violation_error))
 
-    async def test_reported_if_without_error(self) -> None:
+    async def test_reported_if_no_error_is_specified_as_we_can_not_recompute_coroutine_functions(self) -> None:
         async def some_condition() -> bool:
             return False
 
@@ -101,13 +101,22 @@ class TestCoroutine(unittest.IsolatedAsyncioTestCase):
         async def some_func() -> None:
             pass
 
-        value_error = None  # type: Optional[ValueError]
+        runtime_error = None  # type: Optional[RuntimeError]
         try:
             await some_func()
-        except ValueError as err:
-            value_error = err
+        except RuntimeError as err:
+            runtime_error = err
 
-        self.assertIsNotNone(value_error)
+        assert runtime_error is not None
+        assert runtime_error.__cause__ is not None
+        assert isinstance(runtime_error.__cause__, ValueError)
+
+        value_error = runtime_error.__cause__
+
         self.assertRegex(
             str(value_error), r"^Unexpected coroutine function <function .*> as a condition of a contract\. "
             r"You must specify your own error if the condition of your contract is a coroutine function\.")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
If the recomputation of a failed condition raised an exception, the user
was left in the dark which condition triggered the exception.

This patch adds a more informative message, so that the user can at
least inspect the problematic condition or send us a better bug report.