### PR TITLE
Fixed recomputation of calls in generator expr

### DIFF
--- a/icontract/_recompute.py
+++ b/icontract/_recompute.py
@@ -337,6 +337,12 @@ class Visitor(ast.NodeVisitor):
             else:
                 kwargs[keyword.arg] = self.visit(node=keyword.value)
 
+        # If any of the positional or keyword arguments are placeholders, that means that we are re-computing a
+        # generator expression.
+        # As we re-compute them by re-compilation, we do not re-compute the individual calls here.
+        if PLACEHOLDER in args or PLACEHOLDER in kwargs.values():
+            return PLACEHOLDER
+
         result = func(*args, **kwargs)
 
         if inspect.iscoroutine(result):


### PR DESCRIPTION
We re-compute the generator expression by recompilcation. However, we do
descend to display the external inputs of the generator expression, and
ignore the placeholder.

If there was a function call on one or more placeholders, the
re-computation will fail with a cryptic message.

This patch fixes the issue.