### PR TITLE
Released 2.5.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.5.1
+=====
+* Allowed ``__new__`` to tighten pre-conditions (#211)
+* Fixed recomputation of calls in generator expr (#210)
+* Added better reporting on recompute failure (#207)
+
 2.5.0
 =====
 * Encapsulated adding contracts for integrators (#202)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = '2.5.0'
+__version__ = '2.5.1'
 __author__ = 'Marko Ristin'
 __copyright__ = 'Copyright 2019 Parquery AG'
 __license__ = 'MIT'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 setup(
     name='icontract',
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version='2.5.0',
+    version='2.5.1',
     description='Provide design-by-contract with informative violation messages.',
     long_description=long_description,
     url='https://github.com/Parquery/icontract',


### PR DESCRIPTION
* Allowed `__new__` to tighten pre-conditions (#211)
* Fixed recomputation of calls in generator expr (#210)
* Added better reporting on recompute failure (#207)