### PR TITLE
Fixed handling of `self` when passed as kwarg

### DIFF
--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -758,7 +758,7 @@ def _find_self(param_names: List[str], args: Tuple[Any, ...], kwargs: Dict[str, 
     except ValueError:
         pass
 
-    if instance_i is not None:
+    if instance_i is not None and instance_i < len(args):
         return args[instance_i]
 
     return kwargs["self"]

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -35,6 +35,21 @@ class TestOK(unittest.TestCase):
         inst.some_method()
         self.assertEqual(1000, inst.x)
 
+    def test_unbound_instance_method_with_self_as_kwarg(self) -> None:
+        @icontract.invariant(lambda self: self.x > 0)
+        class SomeClass:
+            def __init__(self) -> None:
+                self.x = 100
+
+            def some_method(self) -> None:
+                self.x = 1000
+
+        inst = SomeClass()
+
+        func = inst.some_method.__func__  # type: ignore
+
+        func(self=inst)
+
     def test_magic_method(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
         class SomeClass:

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -400,6 +400,33 @@ class TestInClass(unittest.TestCase):
                          'self was A\n'
                          'self.y was 5', tests.error.wo_mandatory_location(str(violation_error)))
 
+    def test_unbound_instance_method_with_self_as_kwarg(self) -> None:
+        class A:
+            def __init__(self) -> None:
+                self.y = 5
+
+            @icontract.require(lambda self: self.y > 10)
+            def some_method_with_self(self) -> None:
+                pass
+
+            def __repr__(self) -> str:
+                return self.__class__.__name__
+
+        a = A()
+
+        func = a.some_method_with_self.__func__  # type: ignore
+
+        violation_error = None
+        try:
+            func(self=a)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        self.assertIsNotNone(violation_error)
+        self.assertEqual('self.y > 10:\n'
+                         'self was A\n'
+                         'self.y was 5', tests.error.wo_mandatory_location(str(violation_error)))
+
     def test_getter(self) -> None:
         class SomeClass:
             def __init__(self) -> None:


### PR DESCRIPTION
This patch fixes a bug caused when `self` is passed as a keyword
arguments instead as a positional argument..

Usually, `self` is passed as a positional argument so this bug went
unnoticed for a long time. Notably, preconditions and postconditions
worked fine, but the problem surfaced when unbounding an instance method
and passing `self` as keyword argument explicitly.