### PR TITLE
Added reporting of all arguments on violation

### DIFF
--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -176,14 +176,13 @@ def _assert_resolved_kwargs_valid(postconditions: List[Contract],
     return None
 
 
-def _create_violation_error(contract: Contract, resolved_kwargs: Mapping[str, Any],
-                            condition_kwargs: Mapping[str, Any]) -> BaseException:
+def _create_violation_error(contract: Contract, resolved_kwargs: Mapping[str, Any]) -> BaseException:
     """Create the violation error based on the violated contract."""
     exception = None  # type: Optional[BaseException]
 
     if contract.error is None:
         try:
-            msg = icontract._represent.generate_message(contract=contract, condition_kwargs=condition_kwargs)
+            msg = icontract._represent.generate_message(contract=contract, resolved_kwargs=resolved_kwargs)
         except Exception as err:
             parts = ["Failed to recompute the values of the contract condition:\n"]
             if contract.location is not None:
@@ -215,7 +214,7 @@ def _create_violation_error(contract: Contract, resolved_kwargs: Mapping[str, An
                 "The exception class supplied in the contract's error {} is not a subclass of BaseException.".format(
                     contract.error))
 
-        msg = icontract._represent.generate_message(contract=contract, condition_kwargs=condition_kwargs)
+        msg = icontract._represent.generate_message(contract=contract, resolved_kwargs=resolved_kwargs)
         exception = contract.error(msg)
     elif isinstance(contract.error, BaseException):
         exception = contract.error
@@ -255,8 +254,7 @@ async def _assert_preconditions_async(preconditions: List[List[Contract]],
                     check = check_or_coroutine
 
             if not_check(check=check, contract=contract):
-                exception = _create_violation_error(
-                    contract=contract, resolved_kwargs=resolved_kwargs, condition_kwargs=condition_kwargs)
+                exception = _create_violation_error(contract=contract, resolved_kwargs=resolved_kwargs)
                 break
 
         # The group of preconditions was satisfied, no need to check the other groups.
@@ -293,8 +291,7 @@ def _assert_preconditions(preconditions: List[List[Contract]], resolved_kwargs: 
                     contract.condition, func))
 
             if not_check(check=check, contract=contract):
-                exception = _create_violation_error(
-                    contract=contract, resolved_kwargs=resolved_kwargs, condition_kwargs=condition_kwargs)
+                exception = _create_violation_error(contract=contract, resolved_kwargs=resolved_kwargs)
                 break
 
         # The group of preconditions was satisfied, no need to check the other groups.
@@ -373,8 +370,7 @@ async def _assert_postconditions_async(postconditions: List[Contract],
                 check = check_or_coroutine
 
         if not_check(check=check, contract=contract):
-            exception = _create_violation_error(
-                contract=contract, resolved_kwargs=resolved_kwargs, condition_kwargs=condition_kwargs)
+            exception = _create_violation_error(contract=contract, resolved_kwargs=resolved_kwargs)
 
             return exception
 
@@ -401,8 +397,7 @@ def _assert_postconditions(postconditions: List[Contract], resolved_kwargs: Mapp
                 contract.condition, func))
 
         if not_check(check=check, contract=contract):
-            exception = _create_violation_error(
-                contract=contract, resolved_kwargs=resolved_kwargs, condition_kwargs=condition_kwargs)
+            exception = _create_violation_error(contract=contract, resolved_kwargs=resolved_kwargs)
 
             return exception
 
@@ -417,13 +412,7 @@ def _assert_invariant(contract: Contract, instance: Any) -> None:
         check = contract.condition()
 
     if not_check(check=check, contract=contract):
-        if 'self' in contract.condition_arg_set:
-            condition_kwargs = {"self": instance}
-        else:
-            condition_kwargs = dict()
-
-        raise _create_violation_error(
-            contract=contract, resolved_kwargs={'self': instance}, condition_kwargs=condition_kwargs)
+        raise _create_violation_error(contract=contract, resolved_kwargs={'self': instance})
 
 
 def select_capture_kwargs(a_snapshot: Snapshot, resolved_kwargs: Mapping[str, Any]) -> Mapping[str, Any]:

--- a/tests/test_postcondition.py
+++ b/tests/test_postcondition.py
@@ -61,7 +61,9 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('some_condition: result was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual('some_condition:\n'
+                         'result was 1\n'
+                         'x was 1', tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function_with_default_argument_value(self) -> None:
         def some_condition(result: int, y: int = 0) -> bool:
@@ -82,7 +84,9 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('some_condition: result was -1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual('some_condition:\n'
+                         'result was -1\n'
+                         'x was -1', tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function_with_default_argument_value_set(self) -> None:
         def some_condition(result: int, y: int = 0) -> bool:
@@ -105,6 +109,7 @@ class TestViolation(unittest.TestCase):
         self.assertIsNotNone(violation_error)
         self.assertEqual('some_condition:\n'
                          'result was 1\n'
+                         'x was 1\n'
                          'y was 3', tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_description(self) -> None:

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -71,7 +71,9 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("some_condition: x was 1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual("some_condition:\n"
+                         "x was 1\n"
+                         "y was 5", tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function_with_default_argument_value(self) -> None:
         def some_condition(x: int, y: int = 0) -> bool:


### PR DESCRIPTION
Many times in production or debugging it was hard to discern what caused
the violation of the contract since only the condition arguments were
represented in the violation message. This is often not enough to
identify the test case or to give us a hint what might have provoked the
bug.

This patch represents all the arguments of the function call at the time
of violation so that the bugs are easier to trace.