### PR TITLE
Added tracing of `all` on generator expressions

### DIFF
--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -15,7 +15,6 @@ __license__ = 'MIT'
 __status__ = 'Production'
 
 # pylint: disable=invalid-name
-# pylint: disable=protected-access
 # pylint: disable=wrong-import-position
 
 # We need to explicitly assign the aliases instead of using

--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -10,11 +10,9 @@ from icontract._globals import CallableT
 from icontract._types import Contract, Snapshot
 from icontract.errors import ViolationError
 
-# pylint: disable=protected-access
 # pylint does not play with typing.Mapping.
 # pylint: disable=unsubscriptable-object
 # pylint: disable=raising-bad-type
-# pylint: disable=too-many-lines
 
 
 def _walk_decorator_stack(func: CallableT) -> Iterable['CallableT']:
@@ -52,8 +50,6 @@ def kwargs_from_call(param_names: List[str], kwdefaults: Dict[str, Any], args: T
     :param kwargs: keyword arguments supplied to the call
     :return: resolved arguments as they would be passed to the function
     """
-    # pylint: disable=too-many-arguments
-
     # (Marko Ristin, 2020-12-01)
     # Insert _ARGS and _KWARGS preemptively even if they are not needed by any contract.
     # This makes the code logic much simpler since we do not explicitly check if a contract would
@@ -511,7 +507,6 @@ _IN_PROGRESS = threading.local()
 
 def decorate_with_checker(func: CallableT) -> CallableT:
     """Decorate the function with a checker that verifies the preconditions and postconditions."""
-    # pylint: disable=too-many-statements
     assert not hasattr(func, "__preconditions__"), \
         "Expected func to have no list of preconditions (there should be only a single contract checker per function)."
 
@@ -554,8 +549,6 @@ def decorate_with_checker(func: CallableT) -> CallableT:
 
         async def wrapper(*args, **kwargs):  # type: ignore
             """Wrap func by checking the preconditions and postconditions."""
-            # pylint: disable=too-many-branches,too-many-nested-blocks,too-many-locals
-
             kwargs_error = _assert_no_invalid_kwargs(kwargs)
             if kwargs_error:
                 raise kwargs_error
@@ -609,8 +602,6 @@ def decorate_with_checker(func: CallableT) -> CallableT:
 
         def wrapper(*args, **kwargs):  # type: ignore
             """Wrap func by checking the preconditions and postconditions."""
-            # pylint: disable=too-many-branches,too-many-nested-blocks,too-many-locals
-
             kwargs_error = _assert_no_invalid_kwargs(kwargs)
             if kwargs_error:
                 raise kwargs_error
@@ -793,7 +784,6 @@ def _decorate_with_invariants(func: CallableT, is_init: bool) -> CallableT:
     :param is_init: True if the ``func`` is __init__
     :return: function wrapped with invariant checks
     """
-    # pylint: disable=too-many-statements
     if _already_decorated_with_invariants(func=func):
         return func
 
@@ -936,8 +926,6 @@ def _already_decorated_with_invariants(func: CallableT) -> bool:
 
 def add_invariant_checks(cls: type) -> None:
     """Decorate each of the class functions with invariant checks if not already decorated."""
-    # pylint: disable=too-many-branches
-
     # Candidates for the decoration as list of (name, dir() value)
     init_name_func = None  # type: Optional[Tuple[str, Callable[..., None]]]
     names_funcs = []  # type: List[Tuple[str, Callable[..., None]]]

--- a/icontract/_decorators.py
+++ b/icontract/_decorators.py
@@ -8,8 +8,6 @@ import icontract._checkers
 from icontract._globals import CallableT, ExceptionT
 from icontract._types import Contract, Snapshot
 
-# pylint: disable=protected-access
-
 
 class require:  # pylint: disable=invalid-name
     """
@@ -18,7 +16,6 @@ class require:  # pylint: disable=invalid-name
     The arguments of the precondition are expected to be a subset of the arguments of the wrapped function.
     """
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self,
                  condition: Callable[..., Any],
                  description: Optional[str] = None,
@@ -51,7 +48,6 @@ class require:  # pylint: disable=invalid-name
             * An instance of ``BaseException`` that will be raised with the traceback on contract violation.
 
         """
-        # pylint: disable=too-many-arguments
         self.enabled = enabled
         self._contract = None  # type: Optional[Contract]
 
@@ -184,7 +180,6 @@ class ensure:  # pylint: disable=invalid-name
     not have "result" among its arguments.
     """
 
-    # pylint: disable=too-many-instance-attributes
     def __init__(self,
                  condition: Callable[..., Any],
                  description: Optional[str] = None,
@@ -217,7 +212,6 @@ class ensure:  # pylint: disable=invalid-name
               on contract violation.
             * An instance of ``BaseException`` that will be raised with the traceback on contract violation.
         """
-        # pylint: disable=too-many-arguments
         self.enabled = enabled
         self._contract = None  # type: Optional[Contract]
 
@@ -324,7 +318,6 @@ class invariant:  # pylint: disable=invalid-name
         :return:
 
         """
-        # pylint: disable=too-many-arguments
         self.enabled = enabled
         self._contract = None  # type: Optional[Contract]
 

--- a/icontract/_metaclass.py
+++ b/icontract/_metaclass.py
@@ -9,8 +9,6 @@ from typing import List, MutableMapping, Any, Callable, Optional, cast, Set, Typ
 from icontract._types import Contract, Snapshot
 import icontract._checkers
 
-# pylint: disable=protected-access
-
 # Pylint can't deal with multiple Python versions.
 # pylint: disable=arguments-differ
 
@@ -89,9 +87,6 @@ def _collapse_postconditions(base_postconditions: List[Contract], postconditions
 
 def _decorate_namespace_function(bases: List[type], namespace: MutableMapping[str, Any], key: str) -> None:
     """Collect preconditions and postconditions from the bases and decorate the function at the ``key``."""
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-locals
-
     value = namespace[key]
     assert inspect.isfunction(value) or isinstance(value, (staticmethod, classmethod))
 
@@ -175,10 +170,6 @@ def _decorate_namespace_function(bases: List[type], namespace: MutableMapping[st
 
 def _decorate_namespace_property(bases: List[type], namespace: MutableMapping[str, Any], key: str) -> None:
     """Collect contracts for all getters/setters/deleters corresponding to ``key`` and decorate them."""
-    # pylint: disable=too-many-locals
-    # pylint: disable=too-many-branches
-    # pylint: disable=too-many-statements
-
     value = namespace[key]
     assert isinstance(value, property)
 

--- a/icontract/_recompute.py
+++ b/icontract/_recompute.py
@@ -1,4 +1,4 @@
-"""Handle recomputation of values of a function given its abstract syntax tree and function frame."""
+"""Handle re-computation of values of a function given its abstract syntax tree and function frame."""
 
 import ast
 import builtins
@@ -6,8 +6,9 @@ import functools
 import inspect
 import platform
 import sys
-from typing import Any, Mapping, Dict, List, Optional, Union, Tuple, Set, Callable, \
-    cast  # pylint: disable=unused-import
+import uuid
+from typing import (Any, Mapping, Dict, List, Optional, Union, Tuple, Set, Callable, cast, Iterable, TypeVar)  # pylint: disable=unused-import
+from _ast import If
 
 
 class Placeholder:
@@ -21,6 +22,194 @@ class Placeholder:
 PLACEHOLDER = Placeholder()
 
 
+class FirstExceptionInAll:
+    """Represent a first exception case for which an all quantifier does not apply."""
+
+    def __init__(self, result: Any, inputs: Tuple[Tuple[str, Any]]) -> None:
+        """
+        Initialize with the given values.
+
+        :param result: value of the evaluation which was not truthy
+        :param inputs: all the target loop variables set during the iteration
+        """
+        self.result = result
+        self.inputs = inputs
+
+    def __bool__(self) -> Any:
+        """Return the result of the ELT evaluation which invalidated the ``all`` quantifier."""
+        return self.result
+
+
+ContextT = TypeVar('ContextT', bound=ast.expr_context)
+
+
+class _CollectStoredNamesVisitor(ast.NodeVisitor):
+    """Traverse the abstract syntax tree and collect all the names which are stored."""
+
+    def __init__(self) -> None:
+        self.names = []  # type: List[str]
+        self._name_set = set()  # type: Set[str]
+
+    def visit_Name(self, node: ast.Name) -> Any:  # pylint: disable=invalid-name
+        """Collect the name if it is in a store context."""
+        if isinstance(node.ctx, ast.Store) and node.id not in self._name_set:
+            self.names.append(node.id)
+            self._name_set.add(node.id)
+
+
+def _collect_stored_names(nodes: Iterable[ast.expr]) -> List[str]:
+    visitor = _CollectStoredNamesVisitor()
+    for node in nodes:
+        visitor.visit(node)
+    return visitor.names
+
+
+class _CollectNameLoadsVisitor(ast.NodeVisitor):
+    """Traverse the abstract syntax tree and collect all the name nodes in Load context."""
+
+    def __init__(self) -> None:
+        self.nodes = []  # type: List[ast.expr]
+
+    def visit_Name(self, node: ast.Name) -> Any:  # pylint: disable=invalid-name
+        """Collect the name if it is in a load context."""
+        if isinstance(node.ctx, ast.Load):
+            self.nodes.append(node)
+
+
+def _collect_name_loads(nodes: Iterable[ast.expr]) -> List[ast.expr]:
+    visitor = _CollectNameLoadsVisitor()
+    for node in nodes:
+        visitor.visit(node)
+    return visitor.nodes
+
+
+def _translate_all_expression_to_a_module(generator_exp: ast.GeneratorExp, generated_function_name: str,
+                                          name_to_value: Mapping[str, Any]) -> ast.Module:
+    """
+    Generate the AST of the module to trace an all quantifier on an generator expression.
+
+    :param generator_exp: generator expression to be translated
+    :param generated_function_name: UUID of the tracing function to be used in the code
+    :param name_to_value:
+        mapping of all resolved values to the variable names
+        (passed as arguments to the function so that the generation can access them)
+    :return: translation to a module
+    """
+    assert generated_function_name not in name_to_value
+    assert not hasattr(builtins, generated_function_name)
+
+    # Collect all the names involved in the generation
+    relevant_names = _collect_stored_names(generator.target for generator in generator_exp.generators)
+
+    assert generated_function_name not in relevant_names
+
+    # Work backwards, from the most-inner block outwards
+
+    result_id = 'icontract_tracing_all_result_{}'.format(uuid.uuid4().hex)
+    result_assignment = ast.Assign(targets=[ast.Name(id=result_id, ctx=ast.Store())], value=generator_exp.elt)
+
+    exceptional_return = ast.Return(
+        ast.Tuple(
+            elts=[
+                ast.Name(id=result_id, ctx=ast.Load()),
+                ast.Tuple(
+                    elts=[
+                        ast.Tuple(
+                            elts=[
+                                ast.Constant(value=relevant_name, kind=None),
+                                ast.Name(id=relevant_name, ctx=ast.Load())
+                            ],
+                            ctx=ast.Load()) for relevant_name in relevant_names
+                    ],
+                    ctx=ast.Load())
+            ],
+            ctx=ast.Load()))
+
+    # While happy return shall not be executed, we add it here for robustness in case
+    # future refactorings forget to check for that edge case.
+    happy_return = ast.Return(
+        ast.Tuple(elts=[ast.Name(id=result_id, ctx=ast.Load()),
+                        ast.Constant(value=None, kind=None)], ctx=ast.Load()))
+
+    critical_if: If = ast.If(
+        test=ast.Name(id=result_id, ctx=ast.Load()), body=[ast.Pass()], orelse=[exceptional_return])
+
+    # Previous inner block to be added as body to the next outer block
+    block = None  # type: Optional[List[ast.stmt]]
+    for i, comprehension in enumerate(reversed(generator_exp.generators)):
+        if i == 0:
+            # This is the inner-most comprehension.
+            block = [result_assignment, critical_if]
+        assert block is not None
+
+        for condition in reversed(comprehension.ifs):
+            # noinspection PyTypeChecker
+            block = [ast.If(test=condition, body=block, orelse=[])]
+
+        if not comprehension.is_async:
+            # noinspection PyTypeChecker
+            block = [ast.For(target=comprehension.target, iter=comprehension.iter, body=block, orelse=[])]
+        else:
+            # noinspection PyTypeChecker
+            block = [ast.AsyncFor(target=comprehension.target, iter=comprehension.iter, body=block, orelse=[])]
+
+    assert block is not None
+
+    # noinspection PyTypeChecker
+    block.append(happy_return)
+
+    # Now we are ready to generate the function.
+
+    is_async = any(comprehension.is_async for comprehension in generator_exp.generators)
+
+    args = [ast.arg(arg=name, annotation=None) for name in sorted(name_to_value.keys())]
+
+    if platform.python_version_tuple() < ('3', '5'):
+        raise NotImplementedError("Python versions below 3.5 not supported, got: {}".format(platform.python_version()))
+
+    if not is_async:
+        if platform.python_version_tuple() < ('3', '8'):
+            func_def_node = ast.FunctionDef(
+                name=generated_function_name,
+                args=ast.arguments(args=args, kwonlyargs=[], kw_defaults=[], defaults=[], vararg=None, kwarg=None),
+                decorator_list=[],
+                body=block)  # type: Union[ast.FunctionDef, ast.AsyncFunctionDef]
+
+            module_node = ast.Module(body=[func_def_node])
+        else:
+            func_def_node = ast.FunctionDef(
+                name=generated_function_name,
+                args=ast.arguments(
+                    args=args, posonlyargs=[], kwonlyargs=[], kw_defaults=[], defaults=[], vararg=None, kwarg=None),
+                decorator_list=[],
+                body=block)
+
+            module_node = ast.Module(body=[func_def_node], type_ignores=[])
+    else:
+        if platform.python_version_tuple() < ('3', '8'):
+            func_def_node = ast.AsyncFunctionDef(
+                name=generated_function_name,
+                args=ast.arguments(args=args, kwonlyargs=[], kw_defaults=[], defaults=[], vararg=None, kwarg=None),
+                decorator_list=[],
+                body=block)
+
+            module_node = ast.Module(body=[func_def_node])
+        else:
+            func_def_node = ast.AsyncFunctionDef(
+                name=generated_function_name,
+                args=ast.arguments(
+                    args=args, posonlyargs=[], kwonlyargs=[], kw_defaults=[], defaults=[], vararg=None, kwarg=None),
+                decorator_list=[],
+                body=block)
+
+            module_node = ast.Module(body=[func_def_node], type_ignores=[])
+
+    # noinspection PyTypeChecker
+    ast.fix_missing_locations(module_node)
+
+    return module_node
+
+
 class Visitor(ast.NodeVisitor):
     """
     Traverse the abstract syntax tree and recompute the values of each node defined by the function frame.
@@ -31,7 +220,6 @@ class Visitor(ast.NodeVisitor):
 
     # pylint: disable=invalid-name
     # pylint: disable=missing-docstring
-    # pylint: disable=too-many-public-methods
 
     def __init__(self, variable_lookup: List[Mapping[str, Any]]) -> None:
         """
@@ -113,15 +301,19 @@ class Visitor(ast.NodeVisitor):
 
                 # The following assert serves only documentation purposes so that the code is easier to follow.
                 assert isinstance(node.format_spec, ast.JoinedStr)
+                # noinspection PyTypeChecker
                 fmt.append(self.visit(node.format_spec))
 
             fmt.append('}')
 
+            # noinspection PyTypeChecker
             recomputed_value = self.visit(node.value)
+
             return ''.join(fmt).format(recomputed_value)
 
         def visit_JoinedStr(self, node: ast.JoinedStr) -> Any:
             """Visit the values and concatenate them."""
+            # noinspection PyTypeChecker
             joined_str = ''.join(self.visit(value_node) for value_node in node.values)
 
             self.recomputed_values[node] = joined_str
@@ -134,6 +326,7 @@ class Visitor(ast.NodeVisitor):
         if isinstance(node.ctx, ast.Store):
             raise NotImplementedError("Can not compute the value of a Store on a list")
 
+        # noinspection PyTypeChecker
         result = [self.visit(node=elt) for elt in node.elts]
 
         self.recomputed_values[node] = result
@@ -144,6 +337,7 @@ class Visitor(ast.NodeVisitor):
         if isinstance(node.ctx, ast.Store):
             raise NotImplementedError("Can not compute the value of a Store on a tuple")
 
+        # noinspection PyTypeChecker
         result = tuple(self.visit(node=elt) for elt in node.elts)
 
         self.recomputed_values[node] = result
@@ -151,6 +345,7 @@ class Visitor(ast.NodeVisitor):
 
     def visit_Set(self, node: ast.Set) -> Set[Any]:
         """Visit the elements and assemble the results into a set."""
+        # noinspection PyTypeChecker
         result = set(self.visit(node=elt) for elt in node.elts)
 
         self.recomputed_values[node] = result
@@ -163,6 +358,7 @@ class Visitor(ast.NodeVisitor):
             assert isinstance(key, ast.AST)
             assert isinstance(val, ast.AST)
 
+            # noinspection PyTypeChecker
             recomputed_dict[self.visit(node=key)] = self.visit(node=val)
 
         self.recomputed_values[node] = recomputed_dict
@@ -192,6 +388,7 @@ class Visitor(ast.NodeVisitor):
 
     def visit_Expr(self, node: ast.Expr) -> Any:
         """Visit the node's ``value``."""
+        # noinspection PyTypeChecker
         result = self.visit(node=node.value)
 
         self.recomputed_values[node] = result
@@ -200,12 +397,16 @@ class Visitor(ast.NodeVisitor):
     def visit_UnaryOp(self, node: ast.UnaryOp) -> Any:
         """Visit the node operand and apply the operation on the result."""
         if isinstance(node.op, ast.UAdd):
+            # noinspection PyTypeChecker
             result = +self.visit(node=node.operand)
         elif isinstance(node.op, ast.USub):
+            # noinspection PyTypeChecker
             result = -self.visit(node=node.operand)
         elif isinstance(node.op, ast.Not):
+            # noinspection PyTypeChecker
             result = not self.visit(node=node.operand)
         elif isinstance(node.op, ast.Invert):
+            # noinspection PyTypeChecker
             result = ~self.visit(node=node.operand)
         else:
             raise NotImplementedError("Unhandled op of {}: {}".format(node, node.op))
@@ -215,8 +416,9 @@ class Visitor(ast.NodeVisitor):
 
     def visit_BinOp(self, node: ast.BinOp) -> Any:
         """Recursively visit the left and right operand, respectively, and apply the operation on the results."""
-        # pylint: disable=too-many-branches
+        # noinspection PyTypeChecker
         left = self.visit(node=node.left)
+        # noinspection PyTypeChecker
         right = self.visit(node=node.right)
 
         if isinstance(node.op, ast.Add):
@@ -253,6 +455,7 @@ class Visitor(ast.NodeVisitor):
 
     def visit_BoolOp(self, node: ast.BoolOp) -> Any:
         """Recursively visit the operands and apply the operation on them."""
+        # noinspection PyTypeChecker
         values = [self.visit(value_node) for value_node in node.values]
 
         if isinstance(node.op, ast.And):
@@ -267,9 +470,10 @@ class Visitor(ast.NodeVisitor):
 
     def visit_Compare(self, node: ast.Compare) -> Any:
         """Recursively visit the comparators and apply the operations on them."""
-        # pylint: disable=too-many-branches
+        # noinspection PyTypeChecker
         left = self.visit(node=node.left)
 
+        # noinspection PyTypeChecker
         comparators = [self.visit(node=comparator) for comparator in node.comparators]
 
         result = None  # type: Optional[Any]
@@ -309,10 +513,11 @@ class Visitor(ast.NodeVisitor):
 
     def visit_Call(self, node: ast.Call) -> Any:
         """Visit the function and the arguments and finally make the function call with them."""
+        # noinspection PyTypeChecker
         func = self.visit(node=node.func)
 
         if not callable(func):
-            raise ValueError(("Unexpected call to a non-callle during the re-computation: {}").format(func))
+            raise ValueError("Unexpected call to a non-calllable during the re-computation: {}".format(func))
 
         if inspect.iscoroutinefunction(func):
             raise ValueError(
@@ -320,46 +525,64 @@ class Visitor(ast.NodeVisitor):
                  "You must specify your own error if the condition of your contract is a coroutine function."
                  ).format(func))
 
-        args = []  # type: List[Any]
-        for arg_node in node.args:
-            if isinstance(arg_node, ast.Starred):
-                args.extend(self.visit(node=arg_node))
-            else:
-                args.append(self.visit(node=arg_node))
+        # Short-circuit tracing the all quantifier over a generator expression
+        # yapf: disable
+        if (
+                func == builtins.all  # pylint: disable=comparison-with-callable
+                and len(node.args) == 1
+                and isinstance(node.args[0], ast.GeneratorExp)
+        ):
+            # yapf: enable
+            result = self._trace_all_with_generator(func=func, node=node)
+        else:
+            args = []  # type: List[Any]
+            for arg_node in node.args:
+                if isinstance(arg_node, ast.Starred):
+                    # noinspection PyTypeChecker
+                    args.extend(self.visit(node=arg_node))
+                else:
+                    # noinspection PyTypeChecker
+                    args.append(self.visit(node=arg_node))
 
-        kwargs = dict()  # type: Dict[str, Any]
-        for keyword in node.keywords:
-            if keyword.arg is None:
-                kw = self.visit(node=keyword.value)
-                for key, val in kw.items():
-                    kwargs[key] = val
+            kwargs = dict()  # type: Dict[str, Any]
+            for keyword in node.keywords:
+                if keyword.arg is None:
+                    # noinspection PyTypeChecker
+                    kw = self.visit(node=keyword.value)
+                    for key, val in kw.items():
+                        kwargs[key] = val
 
-            else:
-                kwargs[keyword.arg] = self.visit(node=keyword.value)
+                else:
+                    # noinspection PyTypeChecker
+                    kwargs[keyword.arg] = self.visit(node=keyword.value)
 
-        # If any of the positional or keyword arguments are placeholders, that means that we are re-computing a
-        # generator expression.
-        # As we re-compute them by re-compilation, we do not re-compute the individual calls here.
-        if PLACEHOLDER in args or PLACEHOLDER in kwargs.values():
-            return PLACEHOLDER
+            # If any of the positional or keyword arguments are placeholders, that means that we are re-computing a
+            # generator expression.
+            # As we re-compute them by re-compilation, we do not re-compute the individual calls here.
+            if PLACEHOLDER in args or PLACEHOLDER in kwargs.values():
+                return PLACEHOLDER
 
-        result = func(*args, **kwargs)
+            result = func(*args, **kwargs)
 
+        self.recomputed_values[node] = result
         if inspect.iscoroutine(result):
             raise ValueError(
                 ("Unexpected coroutine {} as a result from a call. "
                  "You must specify your own error if the condition of your contract gives a coroutine.").format(result))
 
-        self.recomputed_values[node] = result
+        assert node in self.recomputed_values
         return result
 
     def visit_IfExp(self, node: ast.IfExp) -> Any:
         """Visit the ``test``, and depending on its outcome, the ``body`` or ``orelse``."""
+        # noinspection PyTypeChecker
         test = self.visit(node=node.test)
 
         if test:
+            # noinspection PyTypeChecker
             result = self.visit(node=node.body)
         else:
+            # noinspection PyTypeChecker
             result = self.visit(node=node.orelse)
 
         self.recomputed_values[node] = result
@@ -367,6 +590,7 @@ class Visitor(ast.NodeVisitor):
 
     def visit_Attribute(self, node: ast.Attribute) -> Any:
         """Visit the node's ``value`` and get the attribute from the result."""
+        # noinspection PyTypeChecker
         value = self.visit(node=node.value)
         if not isinstance(node.ctx, ast.Load):
             raise NotImplementedError(
@@ -381,6 +605,7 @@ class Visitor(ast.NodeVisitor):
         # pylint: disable=no-member
         def visit_NamedExpr(self, node: ast.NamedExpr) -> Any:
             """Visit the node's ``value`` and assign it to both this node and the target."""
+            # noinspection PyTypeChecker
             value = self.visit(node=node.value)
             self.recomputed_values[node] = value
 
@@ -397,6 +622,7 @@ class Visitor(ast.NodeVisitor):
 
     def visit_Index(self, node: ast.Index) -> Any:
         """Visit the node's ``value``."""
+        # noinspection PyTypeChecker
         result = self.visit(node=node.value)
 
         self.recomputed_values[node] = result
@@ -406,14 +632,17 @@ class Visitor(ast.NodeVisitor):
         """Visit ``lower``, ``upper`` and ``step`` and recompute the node as a ``slice``."""
         lower = None  # type: Optional[int]
         if node.lower is not None:
+            # noinspection PyTypeChecker
             lower = self.visit(node=node.lower)
 
         upper = None  # type: Optional[int]
         if node.upper is not None:
+            # noinspection PyTypeChecker
             upper = self.visit(node=node.upper)
 
         step = None  # type: Optional[int]
         if node.step is not None:
+            # noinspection PyTypeChecker
             step = self.visit(node=node.step)
 
         result = slice(lower, upper, step)
@@ -423,6 +652,7 @@ class Visitor(ast.NodeVisitor):
 
     def visit_ExtSlice(self, node: ast.ExtSlice) -> Tuple[Any, ...]:
         """Visit each dimension of the advanced slicing and assemble the dimensions in a tuple."""
+        # noinspection PyTypeChecker
         result = tuple(self.visit(node=dim) for dim in node.dims)
 
         self.recomputed_values[node] = result
@@ -430,7 +660,9 @@ class Visitor(ast.NodeVisitor):
 
     def visit_Subscript(self, node: ast.Subscript) -> Any:
         """Visit the ``slice`` and a ``value`` and get the element."""
+        # noinspection PyTypeChecker
         value = self.visit(node=node.value)
+        # noinspection PyTypeChecker
         a_slice = self.visit(node=node.slice)
 
         result = value[a_slice]
@@ -438,12 +670,59 @@ class Visitor(ast.NodeVisitor):
         self.recomputed_values[node] = result
         return result
 
+    def _trace_all_with_generator(self, func: Callable[..., Any], node: ast.Call) -> Any:
+        """Re-write the all call with for loops to trace the first offending item, if any."""
+        assert func == builtins.all  # pylint: disable=comparison-with-callable
+        assert len(node.args) == 1 and isinstance(node.args[0], ast.GeneratorExp)
+
+        # Try the happy path first
+
+        # noinspection PyTypeChecker
+        result = func(*(self.visit(node=node.args[0]), ))
+        if result:
+            return result
+
+        # The all quantifier has not been satisfied. We need to re-trace it.
+        # To that end, we translate the generator expression to a tracing function and
+        # execute it.
+
+        generator_exp = node.args[0]
+
+        generated_function_name = "icontract_tracing_all_with_generator_expr_{}".format(uuid.uuid4().hex)
+
+        module_node = _translate_all_expression_to_a_module(
+            generator_exp=generator_exp,
+            generated_function_name=generated_function_name,
+            name_to_value=self._name_to_value)
+
+        # In case you want to debug the generated function at this point,
+        # you probably want to use ``astor`` module to generate the source code
+        # based on the ``module_node``.
+
+        # noinspection PyTypeChecker
+        code = compile(source=module_node, filename='<ast>', mode='exec')
+
+        module_locals = {}  # type: Dict[str, Any]
+        module_globals = {}  # type: Dict[str, Any]
+        exec(code, module_globals, module_locals)  # pylint: disable=exec-used
+
+        generated_func = module_locals[generated_function_name]
+
+        result, inputs = generated_func(**self._name_to_value)
+
+        assert not bool(result), "Expected the unhappy path here"
+        assert isinstance(inputs, tuple)
+        assert all(isinstance(item, tuple) and len(item) == 2 and isinstance(item[0], str) for item in inputs)
+
+        return FirstExceptionInAll(result=result, inputs=cast(Tuple[Tuple[str, Any]], inputs))
+
     def _execute_comprehension(self, node: Union[ast.ListComp, ast.SetComp, ast.GeneratorExp, ast.DictComp]) -> Any:
         """Compile the generator or comprehension from the node and execute the compiled code."""
-        args = [ast.arg(arg=name) for name in sorted(self._name_to_value.keys())]
+        args = [ast.arg(arg=name, annotation=None) for name in sorted(self._name_to_value.keys())]
 
         if platform.python_version_tuple() < ('3', ):
-            raise NotImplementedError("Python versions below not supported, got: {}".format(platform.python_version()))
+            raise NotImplementedError("Python versions below 3 not supported, got: {}".format(
+                platform.python_version()))
 
         if platform.python_version_tuple() < ('3', '8'):
             func_def_node = ast.FunctionDef(
@@ -462,8 +741,10 @@ class Visitor(ast.NodeVisitor):
 
             module_node = ast.Module(body=[func_def_node], type_ignores=[])
 
+        # noinspection PyTypeChecker
         ast.fix_missing_locations(module_node)
 
+        # noinspection PyTypeChecker
         code = compile(source=module_node, filename='<ast>', mode='exec')
 
         module_locals = {}  # type: Dict[str, Any]
@@ -478,7 +759,14 @@ class Visitor(ast.NodeVisitor):
         """Compile the generator expression as a function and call it."""
         result = self._execute_comprehension(node=node)
 
+        # We can not visit ``node.elt`` as its re-computation would involve evaluating PLACEHOLDER's,
+        # which is of course not possible. Instead, we visit all the names in ``node.elt`` so that they are at least
+        # reported in the representation.
+        for name_node in _collect_name_loads(nodes=[node.elt]):
+            self.visit(name_node)
+
         for generator in node.generators:
+            # noinspection PyTypeChecker
             self.visit(generator.iter)
 
         # Do not set the computed value of the node since its representation would be non-informative.
@@ -489,6 +777,7 @@ class Visitor(ast.NodeVisitor):
         result = self._execute_comprehension(node=node)
 
         for generator in node.generators:
+            # noinspection PyTypeChecker
             self.visit(generator.iter)
 
         self.recomputed_values[node] = result
@@ -499,6 +788,7 @@ class Visitor(ast.NodeVisitor):
         result = self._execute_comprehension(node=node)
 
         for generator in node.generators:
+            # noinspection PyTypeChecker
             self.visit(generator.iter)
 
         self.recomputed_values[node] = result
@@ -509,6 +799,7 @@ class Visitor(ast.NodeVisitor):
         result = self._execute_comprehension(node=node)
 
         for generator in node.generators:
+            # noinspection PyTypeChecker
             self.visit(generator.iter)
 
         self.recomputed_values[node] = result
@@ -517,7 +808,7 @@ class Visitor(ast.NodeVisitor):
     def visit_Lambda(self, node: ast.Lambda) -> Callable[..., Any]:
         """Do not support inline lambda until there is a feature request since this is quite tricky to implement."""
         raise NotImplementedError(
-            "Recomputation of in-line lambda functions is not supported since it is quite tricky to implement and "
+            "Re-computation of in-line lambda functions is not supported since it is quite tricky to implement and "
             "we decided to implement it only once there is a real need for it. "
             "Please make a feature request on https://github.com/Parquery/icontract")
 
@@ -527,4 +818,4 @@ class Visitor(ast.NodeVisitor):
 
     def generic_visit(self, node: ast.AST) -> None:
         """Raise an exception that this node has not been handled."""
-        raise NotImplementedError("Unhandled recomputation of the node: {} {}".format(type(node), node))
+        raise NotImplementedError("Unhandled re-computation of the node: {} {}".format(type(node), node))

--- a/icontract/_types.py
+++ b/icontract/_types.py
@@ -7,13 +7,9 @@ import icontract._globals
 
 from icontract._globals import ExceptionT
 
-# pylint: disable=protected-access
-
 
 class Contract:
     """Represent a contract to be enforced as a precondition, postcondition or as an invariant."""
-
-    # pylint: disable=too-many-instance-attributes
 
     def __init__(self,
                  condition: Callable[..., Any],
@@ -36,7 +32,6 @@ class Contract:
             and raised on contract violation.
         :param location: indicate where the contract was defined (*e.g.*, path and line number)
         """
-        # pylint: disable=too-many-arguments
         self.condition = condition
 
         signature = inspect.signature(condition)

--- a/mypy.ini
+++ b/mypy.ini
@@ -23,3 +23,6 @@ ignore_missing_imports = True
 
 [mypy-asyncstdlib]
 ignore_missing_imports = True
+
+[mypy-astor]
+ignore_missing_imports = True

--- a/pylint.rc
+++ b/pylint.rc
@@ -7,5 +7,5 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,duplicate-code,no-else-raise
+disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,duplicate-code,no-else-raise,too-many-locals,too-many-branches,too-many-lines,too-many-arguments,too-many-statements,too-many-nested-blocks,too-many-function-args,too-many-instance-attributes,too-many-public-methods,protected-access
 

--- a/setup.py
+++ b/setup.py
@@ -49,25 +49,16 @@ setup(
     keywords='design-by-contract precondition postcondition validation',
     packages=find_packages(exclude=['tests']),
     install_requires=install_requires,
+    # yapf: disable
     extras_require={
         'dev': [
-            # yapf: disable
-            'mypy==0.812',
-            'pylint==2.3.1',
-            'yapf==0.20.2',
-            'tox>=3.0.0',
-            'pydocstyle>=2.1.1,<3',
-            'coverage>=4.5.1,<5',
-            'docutils>=0.14,<1',
-            'pygments>=2.2.0,<3',
-            'dpcontracts==0.6.0',
-            'tabulate>=0.8.7,<1',
-            'py-cpuinfo>=5.0.0,<6',
-            'typeguard>=2,<3'
-            # yapf: enable
+            'mypy==0.812', 'pylint==2.3.1', 'yapf==0.20.2', 'tox>=3.0.0', 'pydocstyle>=2.1.1,<3', 'coverage>=4.5.1,<5',
+            'docutils>=0.14,<1', 'pygments>=2.2.0,<3', 'dpcontracts==0.6.0', 'tabulate>=0.8.7,<1',
+            'py-cpuinfo>=5.0.0,<6', 'typeguard>=2,<3', 'astor==0.8.1'
         ] + (['deal==4.1.0'] if sys.version_info >= (3, 8) else []) + (['asyncstdlib==3.9.1']
                                                                        if sys.version_info >= (3, 8) else []),
     },
+    # yapf: enable
     py_modules=['icontract'],
     package_data={"icontract": ["py.typed"]},
     data_files=[(".", ["LICENSE.txt", "README.rst", "requirements.txt"])])

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python3
 
-# pylint: disable=protected-access
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=too-many-function-args
 
 import functools
 import unittest

--- a/tests/test_for_integrators.py
+++ b/tests/test_for_integrators.py
@@ -1,6 +1,6 @@
 """Test logic that can be potentially used by the integrators such as third-party libraries."""
 
-# pylint: disable=protected-access,no-self-use,missing-docstring
+# pylint: disable=no-self-use,missing-docstring
 # pylint: disable=invalid-name,unnecessary-lambda,no-member
 
 import ast

--- a/tests/test_inheritance_precondition.py
+++ b/tests/test_inheritance_precondition.py
@@ -428,7 +428,8 @@ class TestConstructor(unittest.TestCase):
         self.assertEqual(
             textwrap.dedent('''\
                 all(x > 0 for x in xs):
-                all(x > 0 for x in xs) was False
+                all(x > 0 for x in xs) was False, e.g., with
+                  x = -1
                 xs was [-1, -2, -3]'''), tests.error.wo_mandatory_location(str(violation_error)))
 
 

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -562,7 +562,6 @@ class TestInvalid(unittest.TestCase):
 
         type_error = None  # type: Optional[TypeError]
         try:
-            # pylint: disable=too-many-function-args
             some_func(0)  # type: ignore
         except TypeError as err:
             type_error = err

--- a/tests/test_recompute.py
+++ b/tests/test_recompute.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# pylint: disable=missing-docstring,invalid-name,no-self-use
+# pylint: disable=unused-argument
+import ast
+import re
+import textwrap
+import unittest
+
+import astor
+
+# noinspection PyProtectedMember
+import icontract._recompute
+
+
+class TestTranslationForTracingAll(unittest.TestCase):
+    @staticmethod
+    def translate_all_expression(input_source_code: str) -> str:
+        """
+        Parse the input source code and translate it to a module with a tracing function.
+
+        :param input_source_code: source code containing a single ``all`` expression
+        :return:
+            source code of the module with a tracing function.
+            All non-deterministic bits are erased from it.
+        """
+        node = ast.parse(input_source_code)
+        assert isinstance(node, ast.Module)
+        expr_node = node.body[0]
+        assert isinstance(expr_node, ast.Expr)
+        call_node = expr_node.value
+        assert isinstance(call_node, ast.Call)
+        generator_exp = call_node.args[0]
+        assert isinstance(generator_exp, ast.GeneratorExp)
+
+        # We set only SOME_GLOBAL_CONSTANT in ``name_to_value``. In ``_recompute`` module
+        # all the contract arguments will be set including also all the built-ins and other
+        # global variables.
+
+        module_node = icontract._recompute._translate_all_expression_to_a_module(
+            generator_exp=generator_exp,
+            generated_function_name='some_func',
+            name_to_value={'SOME_GLOBAL_CONSTANT': 10})
+
+        got = astor.to_source(module_node)
+
+        # We need to replace the UUID of the result variable for reproducibility.
+        got = re.sub(r'icontract_tracing_all_result_[a-zA-Z0-9]+', 'icontract_tracing_all_result', got)
+
+        assert isinstance(got, str)
+        return got
+
+    def test_global_variable(self) -> None:
+        input_source_code = textwrap.dedent('''\
+            all(
+                x > SOME_GLOBAL_CONSTANT
+                for x in lst
+            )
+            ''')
+
+        got_source_code = TestTranslationForTracingAll.translate_all_expression(input_source_code=input_source_code)
+
+        # Please see ``TestTranslationForTracingAll.translate_all_expression`` and the note about ``name_to_value``
+        # if you wonder why ``lst`` is not in the arguments.
+        self.assertEqual(
+            textwrap.dedent('''\
+                def some_func(SOME_GLOBAL_CONSTANT):
+                    for x in lst:
+                        icontract_tracing_all_result = (x >
+                            SOME_GLOBAL_CONSTANT)
+                        if icontract_tracing_all_result:
+                            pass
+                        else:
+                            return (
+                                icontract_tracing_all_result,
+                                (('x', x),))
+                    return icontract_tracing_all_result, None
+                '''), got_source_code)
+
+    def test_translation_two_fors_and_two_ifs(self) -> None:
+        input_source_code = textwrap.dedent('''\
+            all(
+                cell > SOME_GLOBAL_CONSTANT
+                for i, row in enumerate(matrix)
+                if i > 0
+                for j, cell in enumerate(row)
+                if i == j
+            )
+            ''')
+
+        got_source_code = TestTranslationForTracingAll.translate_all_expression(input_source_code=input_source_code)
+
+        # Please see ``TestTranslationForTracingAll.translate_all_expression`` and the note about ``name_to_value``
+        # if you wonder why ``matrix`` is not in the arguments.
+        self.assertEqual(
+            textwrap.dedent('''\
+                def some_func(SOME_GLOBAL_CONSTANT):
+                    for i, row in enumerate(matrix):
+                        if i > 0:
+                            for j, cell in enumerate(row):
+                                if i == j:
+                                    (icontract_tracing_all_result
+                                        ) = cell > SOME_GLOBAL_CONSTANT
+                                    if (icontract_tracing_all_result
+                                        ):
+                                        pass
+                                    else:
+                                        return (
+                                            icontract_tracing_all_result
+                                            , (('i', i), ('row', row), ('j', j), ('cell',
+                                            cell)))
+                    return icontract_tracing_all_result, None
+                '''), got_source_code)
+
+    def test_nested_all(self) -> None:
+        # Nesting is not recursively followed by design. Only the outer-most all expression should be traced.
+
+        input_source_code = textwrap.dedent('''\
+            all(
+                all(cell > SOME_GLOBAL_CONSTANT for cell in row)
+                for row in matrix
+            )
+            ''')
+
+        got_source_code = TestTranslationForTracingAll.translate_all_expression(input_source_code=input_source_code)
+
+        # Please see ``TestTranslationForTracingAll.translate_all_expression`` and the note about ``name_to_value``
+        # if you wonder why ``matrix`` is not in the arguments.
+        self.assertEqual(
+            textwrap.dedent('''\
+                def some_func(SOME_GLOBAL_CONSTANT):
+                    for row in matrix:
+                        icontract_tracing_all_result = all(
+                            cell > SOME_GLOBAL_CONSTANT for cell in row)
+                        if icontract_tracing_all_result:
+                            pass
+                        else:
+                            return (
+                                icontract_tracing_all_result,
+                                (('row', row),))
+                    return icontract_tracing_all_result, None
+                '''), got_source_code)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests_3_6/test_represent.py
+++ b/tests_3_6/test_represent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-docstring,invalid-name,too-many-public-methods,no-self-use
+# pylint: disable=missing-docstring,invalid-name,no-self-use
 # pylint: disable=unused-argument
 
 import textwrap

--- a/tests_3_8/test_represent.py
+++ b/tests_3_8/test_represent.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-docstring,invalid-name,too-many-public-methods,no-self-use
+# pylint: disable=missing-docstring,invalid-name,no-self-use
 # pylint: disable=unused-argument
-
 import textwrap
 import unittest
 from typing import Optional  # pylint: disable=unused-import
 
+import icontract._recompute
 import icontract._represent
 import tests.error
 import tests.mock


### PR DESCRIPTION
Having conditions using `all` quantifiers is useful to catch bugs, but
it is very cumbersome to trace back what caused the `all` to fail.

This patch implements a tracing of the generator expression in all and
reports the first example in the comprehension which was falsy.