### PR TITLE
Propagated placeholders in re-computation

### DIFF
--- a/pylint.rc
+++ b/pylint.rc
@@ -7,5 +7,5 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,duplicate-code,no-else-raise,too-many-locals,too-many-branches,too-many-lines,too-many-arguments,too-many-statements,too-many-nested-blocks,too-many-function-args,too-many-instance-attributes,too-many-public-methods,protected-access
+disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,duplicate-code,no-else-raise,too-many-locals,too-many-branches,too-many-lines,too-many-arguments,too-many-statements,too-many-nested-blocks,too-many-function-args,too-many-instance-attributes,too-many-public-methods,protected-access,consider-using-in
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 asttokens>=2,<3
+typing_extensions


### PR DESCRIPTION
So far, the re-computation stopped at generator expressions. However,
there might have been relevant parts which should be re-computed beneath
the AST of the generator expression.

This patch handles propagation of `PLACEHOLDER`'s and allows the
re-computation visitor to visit all the descendant AST nodes.