### PR TITLE
Fixed reporting all arguments on violation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,9 @@ The script is also available as a `repl.it post`_.
     Traceback (most recent call last):
       ...
     icontract.errors.ViolationError: File <doctest README.rst[1]>, line 1 in <module>:
-    x > 3: x was 1
+    x > 3:
+    x was 1
+    y was 5
 
     # Pre-condition violation with a description
     >>> @icontract.require(lambda x: x > 3, "x must not be small")
@@ -127,7 +129,9 @@ The script is also available as a `repl.it post`_.
     Traceback (most recent call last):
       ...
     icontract.errors.ViolationError: File <doctest README.rst[4]>, line 1 in <module>:
-    x must not be small: x > 3: x was 1
+    x must not be small: x > 3:
+    x was 1
+    y was 5
 
     # Pre-condition violation with more complex values
     >>> class B:
@@ -176,6 +180,7 @@ The script is also available as a `repl.it post`_.
     result > x:
     result was 5
     x was 10
+    y was 5
 
 
     # Pre-conditions fail before post-conditions.
@@ -188,7 +193,9 @@ The script is also available as a `repl.it post`_.
     Traceback (most recent call last):
       ...
     icontract.errors.ViolationError: File <doctest README.rst[14]>, line 2 in <module>:
-    x must not be small: x > 3: x was 3
+    x must not be small: x > 3:
+    x was 3
+    y was 5
 
     # Invariant
     >>> @icontract.invariant(lambda self: self.x > 0)

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -43,7 +43,9 @@ If you want to customize the error, see Section :ref:`Custom Errors`.
     Traceback (most recent call last):
       ...
     icontract.errors.ViolationError: File <doctest usage.rst[1]>, line 1 in <module>:
-    x > 3: x was 1
+    x > 3:
+    x was 1
+    y was 5
 
     # Pre-condition violation with a description
     >>> @icontract.require(lambda x: x > 3, "x must not be small")
@@ -54,7 +56,9 @@ If you want to customize the error, see Section :ref:`Custom Errors`.
     Traceback (most recent call last):
       ...
     icontract.errors.ViolationError: File <doctest usage.rst[4]>, line 1 in <module>:
-    x must not be small: x > 3: x was 1
+    x must not be small: x > 3:
+    x was 1
+    y was 5
 
     # Pre-condition violation with more complex values
     >>> class B:
@@ -65,14 +69,14 @@ If you want to customize the error, see Section :ref:`Custom Errors`.
     ...         return 2
     ...
     ...     def __repr__(self) -> str:
-    ...         return "instance of B"
+    ...         return "an instance of B"
     ...
     >>> class A:
     ...     def __init__(self)->None:
     ...         self.b = B()
     ...
     ...     def __repr__(self) -> str:
-    ...         return "instance of A"
+    ...         return "an instance of A"
     ...
     >>> SOME_GLOBAL_VAR = 13
     >>> @icontract.require(lambda a: a.b.x + a.b.y() > SOME_GLOBAL_VAR)
@@ -86,8 +90,8 @@ If you want to customize the error, see Section :ref:`Custom Errors`.
     icontract.errors.ViolationError: File <doctest usage.rst[9]>, line 1 in <module>:
     a.b.x + a.b.y() > SOME_GLOBAL_VAR:
     SOME_GLOBAL_VAR was 13
-    a was instance of A
-    a.b was instance of B
+    a was an instance of A
+    a.b was an instance of B
     a.b.x was 7
     a.b.y() was 2
 
@@ -103,6 +107,7 @@ If you want to customize the error, see Section :ref:`Custom Errors`.
     result > x:
     result was 5
     x was 10
+    y was 5
 
 Invariants
 ----------
@@ -261,6 +266,7 @@ Here is an example that uses snapshots to check that a value was appended to the
     OLD was a bunch of OLD values
     OLD.lst was [1, 2]
     lst was [1, 2, 3, 1984]
+    result was None
     value was 3
 
 The following example shows how you can name the snapshot:
@@ -285,6 +291,8 @@ The following example shows how you can name the snapshot:
     OLD.len_lst was 2
     len(lst) was 4
     lst was [1, 2, 3, 1984]
+    result was None
+    value was 3
 
 The next code snippet shows how you can combine multiple arguments of a function to be captured in a single snapshot:
 
@@ -309,6 +317,7 @@ The next code snippet shows how you can combine multiple arguments of a function
     OLD.union was {1, 2, 3, 4}
     lst_a was [1, 2, 1984]
     lst_b was [3, 4]
+    result was None
     set(lst_a) was {1, 2, 1984}
     set(lst_a).union(lst_b) was {1, 2, 3, 4, 1984}
 
@@ -362,7 +371,7 @@ The following example shows an abstract parent class and a child class that inhe
         ...         pass
         ...
         ...     def __repr__(self) -> str:
-        ...         return "instance of A"
+        ...         return "an instance of A"
 
         >>> @icontract.invariant(lambda self: self.x < 100)
         ... class B(A):
@@ -378,7 +387,7 @@ The following example shows an abstract parent class and a child class that inhe
         ...         self.x = 101
         ...
         ...     def __repr__(self) -> str:
-        ...         return "instance of B"
+        ...         return "an instance of B"
 
         # Break the parent's postcondition
         >>> some_b = B()
@@ -388,6 +397,7 @@ The following example shows an abstract parent class and a child class that inhe
         icontract.errors.ViolationError: File <doctest usage.rst[40]>, line 7 in A:
         result < y:
         result was 1
+        self was an instance of B
         y was 0
 
         # Break the parent's invariant
@@ -397,7 +407,7 @@ The following example shows an abstract parent class and a child class that inhe
             ...
         icontract.errors.ViolationError: File <doctest usage.rst[40]>, line 1 in <module>:
         self.x > 0:
-        self was instance of B
+        self was an instance of B
         self.x was -1
 
         # Break the child's invariant
@@ -407,7 +417,7 @@ The following example shows an abstract parent class and a child class that inhe
             ...
         icontract.errors.ViolationError: File <doctest usage.rst[41]>, line 1 in <module>:
         self.x < 100:
-        self was instance of B
+        self was an instance of B
         self.x was 101
 
 The following example shows how preconditions are weakened:
@@ -423,6 +433,10 @@ The following example shows how preconditions are weakened:
         ...     @icontract.require(lambda x: x % 3 == 0)
         ...     def func(self, x: int) -> None:
         ...         pass
+        ...
+        ...     def __repr__(self) -> str:
+        ...         return "an instance of B"
+
 
         >>> b = B()
 
@@ -440,7 +454,9 @@ The following example shows how preconditions are weakened:
         Traceback (most recent call last):
             ...
         icontract.errors.ViolationError: File <doctest usage.rst[49]>, line 2 in B:
-        x % 3 == 0: x was 5
+        x % 3 == 0:
+        self was an instance of B
+        x was 5
 
 The example below illustrates how snapshots are inherited:
 
@@ -459,6 +475,10 @@ The example below illustrates how snapshots are inherited:
         ...     def func(self, lst: List[int], value: int) -> None:
         ...         lst.append(value)
         ...         lst.append(1984)  # bug
+        ...
+        ...     def __repr__(self) -> str:
+        ...         return "an instance of B"
+
 
         >>> b = B()
         >>> b.func(lst=[1, 2], value=3)
@@ -471,6 +491,9 @@ The example below illustrates how snapshots are inherited:
         len(OLD.lst) was 2
         len(lst) was 4
         lst was [1, 2, 3, 1984]
+        result was None
+        self was an instance of B
+        value was 3
 
 
 Toggling Contracts

--- a/tests/test_args_and_kwargs_in_contract.py
+++ b/tests/test_args_and_kwargs_in_contract.py
@@ -100,6 +100,7 @@ class TestArgs(unittest.TestCase):
             textwrap.dedent('''\
                 len(_ARGS) > 2:
                 _ARGS was (3,)
+                args was 3
                 len(_ARGS) was 1'''), tests.error.wo_mandatory_location(str(violation_error)))
 
 
@@ -185,8 +186,10 @@ class TestKwargs(unittest.TestCase):
 
         assert violation_error is not None
         self.assertEqual(
-            textwrap.dedent("'x' in _KWARGS: _KWARGS was {'y': 3}"),
-            tests.error.wo_mandatory_location(str(violation_error)))
+            textwrap.dedent("""\
+                'x' in _KWARGS:
+                _KWARGS was {'y': 3}
+                y was 3"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestArgsAndKwargs(unittest.TestCase):

--- a/tests/test_inheritance_invariant.py
+++ b/tests/test_inheritance_invariant.py
@@ -4,6 +4,7 @@
 # pylint: disable=no-member
 
 import abc
+import textwrap
 import unittest
 from typing import Optional  # pylint: disable=unused-import
 
@@ -237,7 +238,7 @@ class TestProperty(unittest.TestCase):
 
         class SomeClass(SomeBase):
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -249,7 +250,7 @@ class TestProperty(unittest.TestCase):
 
         self.assertIsNotNone(violation_error)
         self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
+                         'self was an instance of SomeClass\n'
                          'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inherited_setter(self) -> None:
@@ -268,7 +269,7 @@ class TestProperty(unittest.TestCase):
 
         class SomeClass(SomeBase):
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -279,9 +280,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inherited_deleter(self) -> None:
         @icontract.invariant(lambda self: not self.toggled)
@@ -299,7 +302,7 @@ class TestProperty(unittest.TestCase):
 
         class SomeClass(SomeBase):
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -310,9 +313,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inherited_invariant_on_getter(self) -> None:
         @icontract.invariant(lambda self: not self.toggled)
@@ -327,7 +332,7 @@ class TestProperty(unittest.TestCase):
                 return 0
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -338,9 +343,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inherited_invariant_on_setter(self) -> None:
         @icontract.invariant(lambda self: not self.toggled)
@@ -358,7 +365,7 @@ class TestProperty(unittest.TestCase):
                 self.toggled = True
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -369,9 +376,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inherited_invariant_on_deleter(self) -> None:
         @icontract.invariant(lambda self: not self.toggled)
@@ -389,7 +398,7 @@ class TestProperty(unittest.TestCase):
                 self.toggled = True
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -400,9 +409,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 if __name__ == '__main__':

--- a/tests/test_inheritance_precondition.py
+++ b/tests/test_inheritance_precondition.py
@@ -55,7 +55,8 @@ class TestViolation(unittest.TestCase):
                 pass
 
         class B(A):
-            pass
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
 
         b = B()
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -65,7 +66,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x < 100: x was 1000", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < 100:
+                self was an instance of B
+                x was 1000"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inherited_with_implementation(self) -> None:
         class A(icontract.DBC):
@@ -77,6 +82,9 @@ class TestViolation(unittest.TestCase):
             def func(self, x: int) -> None:
                 pass
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         b = B()
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -85,7 +93,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x < 100: x was 1000", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < 100:
+                self was an instance of B
+                x was 1000"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_require_else(self) -> None:
         class A(icontract.DBC):
@@ -98,6 +110,9 @@ class TestViolation(unittest.TestCase):
             def func(self, x: int) -> None:
                 pass
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         b = B()
 
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -107,7 +122,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x % 3 == 0: x was 5", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x % 3 == 0:
+                self was an instance of B
+                x was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_triple_inheritance_wo_implementation(self) -> None:
         class A(icontract.DBC):
@@ -116,10 +135,12 @@ class TestViolation(unittest.TestCase):
                 pass
 
         class B(A):
-            pass
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
 
         class C(B):
-            pass
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
 
         c = C()
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -129,7 +150,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x < 100: x was 1000", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < 100:
+                self was an instance of C
+                x was 1000"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_triple_inheritance_with_implementation(self) -> None:
         class A(icontract.DBC):
@@ -144,6 +169,9 @@ class TestViolation(unittest.TestCase):
             def func(self, x: int) -> None:
                 pass
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         c = C()
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -152,7 +180,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x < 100: x was 1000", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < 100:
+                self was an instance of C
+                x was 1000"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_triple_inheritance_with_require_else(self) -> None:
         class A(icontract.DBC):
@@ -170,6 +202,9 @@ class TestViolation(unittest.TestCase):
             def func(self, x: int) -> None:
                 pass
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         c = C()
 
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -179,7 +214,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x % 5 == 0: x was 7", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x % 5 == 0:
+                self was an instance of C
+                x was 7"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_abstract_method(self) -> None:
         class A(icontract.DBC):
@@ -192,6 +231,9 @@ class TestViolation(unittest.TestCase):
             def func(self, x: int) -> int:
                 return 1000
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         b = B()
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -200,7 +242,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x > 0: x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x > 0:
+                self was an instance of B
+                x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_that_base_preconditions_apply_to_init_if_not_defined(self) -> None:
         class A(icontract.DBC):
@@ -209,7 +255,8 @@ class TestViolation(unittest.TestCase):
                 pass
 
         class B(A):
-            pass
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # Optional[icontract.ViolationError]
         try:
@@ -218,7 +265,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x >= 0: x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x >= 0:
+                self was an instance of B
+                x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_that_base_preconditions_dont_apply_to_init_if_overridden(self) -> None:
         class A(icontract.DBC):
@@ -232,6 +283,9 @@ class TestViolation(unittest.TestCase):
             def __init__(self, x: int) -> None:
                 pass
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         # Preconditions of B need to be satisfied, but not from A
         _ = B(x=-100)
 
@@ -242,7 +296,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x < 0: x was 0", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < 0:
+                self was an instance of B
+                x was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestPropertyOK(unittest.TestCase):
@@ -295,7 +353,7 @@ class TestPropertyViolation(unittest.TestCase):
                 return 0
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -306,9 +364,11 @@ class TestPropertyViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_setter(self) -> None:
         class SomeBase(icontract.DBC):
@@ -328,7 +388,7 @@ class TestPropertyViolation(unittest.TestCase):
                 pass
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -339,7 +399,11 @@ class TestPropertyViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('value > 0: value was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                value > 0:
+                self was an instance of SomeClass
+                value was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_deleter(self) -> None:
         class SomeBase(icontract.DBC):
@@ -357,7 +421,7 @@ class TestPropertyViolation(unittest.TestCase):
 
         class SomeClass(SomeBase):
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
             # pylint: disable=no-member
             @SomeBase.some_prop.deleter  # type: ignore
@@ -373,9 +437,11 @@ class TestPropertyViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestConstructor(unittest.TestCase):
@@ -392,6 +458,9 @@ class TestConstructor(unittest.TestCase):
             def __init__(self, x: int) -> None:
                 super().__init__(x=x)
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         _ = B(3)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -401,7 +470,11 @@ class TestConstructor(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('x > 0: x was -1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x > 0:
+                self was an instance of B
+                x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_new_tightens_preconditions(self) -> None:
         class A(icontract.DBC):
@@ -415,6 +488,9 @@ class TestConstructor(unittest.TestCase):
             @icontract.require(lambda xs: all(x > 0 for x in xs))
             def __new__(cls, xs: Sequence[int]) -> 'B':
                 return cast(B, xs)
+
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
 
         _ = B([1, 2, 3])
 

--- a/tests/test_inheritance_snapshot.py
+++ b/tests/test_inheritance_snapshot.py
@@ -1,6 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
-
+import textwrap
 import unittest
 from typing import Optional, List  # pylint: disable=unused-import
 
@@ -41,7 +41,7 @@ class TestViolation(unittest.TestCase):
 
         class B(A):
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         b = B()
 
@@ -52,12 +52,15 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('OLD.lst + [val] == self.lst:\n'
-                         'OLD was a bunch of OLD values\n'
-                         'OLD.lst was []\n'
-                         'self was B\n'
-                         'self.lst was [2, 1984]\n'
-                         'val was 2', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                OLD.lst + [val] == self.lst:
+                OLD was a bunch of OLD values
+                OLD.lst was []
+                result was None
+                self was an instance of B
+                self.lst was [2, 1984]
+                val was 2"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_inherited_snapshot(self) -> None:
         class A(icontract.DBC):
@@ -76,7 +79,7 @@ class TestViolation(unittest.TestCase):
                 self.lst.append(1984)
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         b = B()
 
@@ -87,12 +90,16 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('OLD.len_lst + 1 == len(self.lst):\n'
-                         'OLD was a bunch of OLD values\n'
-                         'OLD.len_lst was 0\n'
-                         'len(self.lst) was 2\n'
-                         'self was B\n'
-                         'self.lst was [2, 1984]', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                OLD.len_lst + 1 == len(self.lst):
+                OLD was a bunch of OLD values
+                OLD.len_lst was 0
+                len(self.lst) was 2
+                result was None
+                self was an instance of B
+                self.lst was [2, 1984]
+                val was 2"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestPropertyOK(unittest.TestCase):
@@ -168,7 +175,7 @@ class TestPropertyViolation(unittest.TestCase):
 
         class SomeClass(SomeBase):
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -180,11 +187,14 @@ class TestPropertyViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.gets == OLD.gets + 1:\n'
-                         'OLD was a bunch of OLD values\n'
-                         'OLD.gets was 0\n'
-                         'self was SomeClass\n'
-                         'self.gets was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.gets == OLD.gets + 1:
+                OLD was a bunch of OLD values
+                OLD.gets was 0
+                result was 0
+                self was an instance of SomeClass
+                self.gets was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
         # setter fails
         violation_error = None
@@ -194,11 +204,15 @@ class TestPropertyViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.sets == OLD.sets + 1:\n'
-                         'OLD was a bunch of OLD values\n'
-                         'OLD.sets was 0\n'
-                         'self was SomeClass\n'
-                         'self.sets was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.sets == OLD.sets + 1:
+                OLD was a bunch of OLD values
+                OLD.sets was 0
+                result was None
+                self was an instance of SomeClass
+                self.sets was 0
+                value was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
         # deleter fails
         violation_error = None
@@ -208,11 +222,14 @@ class TestPropertyViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.dels == OLD.dels + 1:\n'
-                         'OLD was a bunch of OLD values\n'
-                         'OLD.dels was 0\n'
-                         'self was SomeClass\n'
-                         'self.dels was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.dels == OLD.dels + 1:
+                OLD was a bunch of OLD values
+                OLD.dels was 0
+                result was None
+                self was an instance of SomeClass
+                self.dels was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestInvalid(unittest.TestCase):

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -2,7 +2,7 @@
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 # pylint: disable=no-member
-
+import textwrap
 import time
 import unittest
 from typing import Dict, Iterator, Mapping, Optional, Any, NamedTuple  # pylint: disable=unused-import
@@ -419,7 +419,7 @@ class TestViolation(unittest.TestCase):
                 self.x = -1
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -429,7 +429,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("y > 0: y was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                y > 0:
+                self was an instance of SomeClass
+                y was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
         violation_error = None
         try:
@@ -439,9 +443,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was some instance\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of SomeClass
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inv_ok_but_post_violated(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -455,7 +461,7 @@ class TestViolation(unittest.TestCase):
                 return -1
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -465,7 +471,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("result > 0: result was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result > 0:
+                result was -1
+                self was an instance of SomeClass"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inv_violated_but_post_ok(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -498,7 +508,8 @@ class TestViolation(unittest.TestCase):
 
         @icontract.invariant(lambda: z != 42)
         class A:
-            pass
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -507,7 +518,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("z != 42: z was 42", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                z != 42:
+                self was an instance of A
+                z was 42"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function(self) -> None:
         def some_condition(self: 'A') -> bool:
@@ -579,7 +594,7 @@ class TestProperty(unittest.TestCase):
                 return 0
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -590,9 +605,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_property_setter(self) -> None:
         @icontract.invariant(lambda self: not self.toggled)
@@ -609,7 +626,7 @@ class TestProperty(unittest.TestCase):
                 self.toggled = True
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -620,9 +637,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_property_deleter(self) -> None:
         @icontract.invariant(lambda self: not self.toggled)
@@ -639,7 +658,7 @@ class TestProperty(unittest.TestCase):
                 self.toggled = True
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -650,9 +669,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestError(unittest.TestCase):
@@ -663,7 +684,7 @@ class TestError(unittest.TestCase):
                 self.x = 0
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         value_error = None  # type: Optional[ValueError]
         try:
@@ -673,9 +694,11 @@ class TestError(unittest.TestCase):
 
         self.assertIsNotNone(value_error)
         self.assertIsInstance(value_error, ValueError)
-        self.assertEqual('self.x > 0:\n'
-                         'self was A\n'
-                         'self.x was 0', tests.error.wo_mandatory_location(str(value_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of A
+                self.x was 0"""), tests.error.wo_mandatory_location(str(value_error)))
 
     def test_as_function(self) -> None:
         @icontract.invariant(
@@ -685,7 +708,7 @@ class TestError(unittest.TestCase):
                 self.x = 0
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         value_error = None  # type: Optional[ValueError]
         try:
@@ -704,7 +727,7 @@ class TestError(unittest.TestCase):
                 self.x = 0
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         value_error = None  # type: Optional[ValueError]
         try:

--- a/tests/test_postcondition.py
+++ b/tests/test_postcondition.py
@@ -6,6 +6,7 @@
 
 import abc
 import functools
+import textwrap
 import unittest
 from typing import Optional, List, Type  # pylint: disable=unused-import
 
@@ -38,9 +39,12 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("result > x:\n"
-                         "result was -4\n"
-                         "x was 1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result > x:
+                result was -4
+                x was 1
+                y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function(self) -> None:
         def some_condition(result: int) -> bool:
@@ -61,9 +65,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('some_condition:\n'
-                         'result was 1\n'
-                         'x was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                some_condition:
+                result was 1
+                x was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function_with_default_argument_value(self) -> None:
         def some_condition(result: int, y: int = 0) -> bool:
@@ -84,9 +90,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('some_condition:\n'
-                         'result was -1\n'
-                         'x was -1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                some_condition:
+                result was -1
+                x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function_with_default_argument_value_set(self) -> None:
         def some_condition(result: int, y: int = 0) -> bool:
@@ -124,9 +132,12 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("expected summation: result > x:\n"
-                         "result was -4\n"
-                         "x was 1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                expected summation: result > x:
+                result was -4
+                x was 1
+                y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_stacked_decorators(self) -> None:
         def mydecorator(f: CallableT) -> CallableT:
@@ -154,10 +165,13 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("y > result + another_var:\n"
-                         "another_var was 2\n"
-                         "result was 100\n"
-                         "y was 10", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                y > result + another_var:
+                another_var was 2
+                result was 100
+                x was 0
+                y was 10"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_default_values_outer(self) -> None:
         @icontract.ensure(lambda result, c: result % c == 0)
@@ -173,9 +187,13 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("result % c == 0:\n"
-                         "c was 2\n"
-                         "result was 13", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result % c == 0:
+                a was 13
+                b was 21
+                c was 2
+                result was 13"""), tests.error.wo_mandatory_location(str(violation_error)))
 
         # Check the inner post condition
         violation_error = None
@@ -185,9 +203,13 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("result < b:\n"
-                         "b was 21\n"
-                         "result was 36", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result < b:
+                a was 36
+                b was 21
+                c was 2
+                result was 36"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_only_result(self) -> None:
         @icontract.ensure(lambda result: result > 3)
@@ -201,7 +223,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("result > 3: result was 0", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result > 3:
+                result was 0
+                x was 10000"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestError(unittest.TestCase):
@@ -218,7 +244,11 @@ class TestError(unittest.TestCase):
 
         self.assertIsNotNone(value_error)
         self.assertIsInstance(value_error, ValueError)
-        self.assertEqual('result > 0: result was 0', tests.error.wo_mandatory_location(str(value_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result > 0:
+                result was 0
+                x was 0"""), tests.error.wo_mandatory_location(str(value_error)))
 
     def test_as_function(self) -> None:
         @icontract.ensure(lambda result: result > 0, error=lambda result: ValueError("result must be positive."))
@@ -301,7 +331,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('result != 0: result was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result != 0:
+                result was 0
+                x was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_postcondition_in_class_method(self) -> None:
         class SomeClass:
@@ -320,7 +354,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('result != 0: result was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result != 0:
+                result was 0
+                x was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_postcondition_in_abstract_static_method(self) -> None:
         class SomeAbstract(icontract.DBC):
@@ -344,7 +382,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('result != 0: result was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result != 0:
+                result was 0
+                x was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_postcondition_in_abstract_class_method(self) -> None:
         class Abstract(icontract.DBC):
@@ -369,7 +411,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('result != 0: result was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result != 0:
+                result was 0
+                x was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_getter(self) -> None:
         class SomeClass:
@@ -381,6 +427,9 @@ class TestInClass(unittest.TestCase):
             def some_prop(self) -> int:
                 return self._some_prop
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         some_inst = SomeClass()
 
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -390,7 +439,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('result > 0: result was -1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                result > 0:
+                result was -1
+                self was an instance of SomeClass"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_setter(self) -> None:
         class SomeClass:
@@ -404,7 +457,7 @@ class TestInClass(unittest.TestCase):
                 pass
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -415,9 +468,13 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.some_prop > 0:\n'
-                         'self was SomeClass\n'
-                         'self.some_prop was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.some_prop > 0:
+                result was None
+                self was an instance of SomeClass
+                self.some_prop was 0
+                value was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_deleter(self) -> None:
         class SomeClass:
@@ -434,7 +491,7 @@ class TestInClass(unittest.TestCase):
                 pass
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -445,8 +502,12 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.some_prop > 0:\nself was SomeClass\nself.some_prop was -1',
-                         tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.some_prop > 0:
+                result was None
+                self was an instance of SomeClass
+                self.some_prop was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 if __name__ == '__main__':

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -40,7 +40,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x > 3: x was 1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x > 3:
+                x was 1
+                y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_description(self) -> None:
         @icontract.require(lambda x: x > 3, "x must not be small")
@@ -54,7 +58,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x must not be small: x > 3: x was 1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x must not be small: x > 3:
+                x was 1
+                y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function(self) -> None:
         def some_condition(x: int) -> bool:
@@ -199,7 +207,12 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("c < 10: c was 22", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                c < 10:
+                a was 2
+                b was 21
+                c was 22"""), tests.error.wo_mandatory_location(str(violation_error)))
 
         violation_error = None
         try:
@@ -208,7 +221,12 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("b < 10: b was 21", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                b < 10:
+                a was 2
+                b was 21
+                c was 8"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestBenchmark(unittest.TestCase):
@@ -376,7 +394,7 @@ class TestInClass(unittest.TestCase):
                 pass
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         a = A()
 
@@ -388,7 +406,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x > 3: x was 1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x > 3:
+                self was an instance of A
+                x was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
         # Test method with self
         violation_error = None
@@ -398,9 +420,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.y > 10:\n'
-                         'self was A\n'
-                         'self.y was 5', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.y > 10:
+                self was an instance of A
+                self.y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_unbound_instance_method_with_self_as_kwarg(self) -> None:
         class A:
@@ -412,7 +436,7 @@ class TestInClass(unittest.TestCase):
                 pass
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         a = A()
 
@@ -425,9 +449,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.y > 10:\n'
-                         'self was A\n'
-                         'self.y was 5', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.y > 10:
+                self was an instance of A
+                self.y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_getter(self) -> None:
         class SomeClass:
@@ -440,7 +466,7 @@ class TestInClass(unittest.TestCase):
                 return self._some_prop
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -451,9 +477,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self._some_prop > 0:\n'
-                         'self was SomeClass\n'
-                         'self._some_prop was -1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self._some_prop > 0:
+                self was an instance of SomeClass
+                self._some_prop was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_setter(self) -> None:
         class SomeClass:
@@ -466,6 +494,9 @@ class TestInClass(unittest.TestCase):
             def some_prop(self, value: int) -> None:
                 pass
 
+            def __repr__(self) -> str:
+                return "an instance of {}".format(self.__class__.__name__)
+
         some_inst = SomeClass()
 
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -475,7 +506,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('value > 0: value was -1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                value > 0:
+                self was an instance of SomeClass
+                value was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_deleter(self) -> None:
         class SomeClass:
@@ -492,7 +527,7 @@ class TestInClass(unittest.TestCase):
                 pass
 
             def __repr__(self) -> str:
-                return self.__class__.__name__
+                return "an instance of {}".format(self.__class__.__name__)
 
         some_inst = SomeClass()
 
@@ -503,8 +538,11 @@ class TestInClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.some_prop > 0:\nself was SomeClass\nself.some_prop was -1',
-                         tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.some_prop > 0:
+                self was an instance of SomeClass
+                self.some_prop was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestInvalid(unittest.TestCase):

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -65,11 +65,14 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('OLD.lst + [val] == lst:\n'
-                         'OLD was a bunch of OLD values\n'
-                         'OLD.lst was [1]\n'
-                         'lst was [1, 2, 1984]\n'
-                         'val was 2', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                OLD.lst + [val] == lst:
+                OLD was a bunch of OLD values
+                OLD.lst was [1]
+                lst was [1, 2, 1984]
+                result was None
+                val was 2"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_custom_name(self) -> None:
         @icontract.snapshot(lambda lst: len(lst), name="len_lst")
@@ -85,11 +88,15 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('OLD.len_lst + 1 == len(lst):\n'
-                         'OLD was a bunch of OLD values\n'
-                         'OLD.len_lst was 1\n'
-                         'len(lst) was 3\n'
-                         'lst was [1, 2, 1984]', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                OLD.len_lst + 1 == len(lst):
+                OLD was a bunch of OLD values
+                OLD.len_lst was 1
+                len(lst) was 3
+                lst was [1, 2, 1984]
+                result was None
+                val was 2"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_multiple_arguments(self) -> None:
         @icontract.snapshot(lambda lst_a, lst_b: set(lst_a).union(lst_b), name="union")
@@ -106,13 +113,15 @@ class TestViolation(unittest.TestCase):
         self.assertIsNotNone(violation_error)
         self.assertEqual(
             textwrap.dedent('''\
-            set(lst_a).union(lst_b) == OLD.union:
-            OLD was a bunch of OLD values
-            OLD.union was {1, 2, 3, 4}
-            lst_a was [1, 2, 1984]
-            lst_b was [3, 4]
-            set(lst_a) was {1, 2, 1984}
-            set(lst_a).union(lst_b) was {1, 2, 3, 4, 1984}'''), tests.error.wo_mandatory_location(str(violation_error)))
+                set(lst_a).union(lst_b) == OLD.union:
+                OLD was a bunch of OLD values
+                OLD.union was {1, 2, 3, 4}
+                lst_a was [1, 2, 1984]
+                lst_b was [3, 4]
+                result was None
+                set(lst_a) was {1, 2, 1984}
+                set(lst_a).union(lst_b) was {1, 2, 3, 4, 1984}'''),
+            tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestInvalid(unittest.TestCase):

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -111,7 +111,7 @@ class TestInvariant(unittest.TestCase):
                 self.x = x
 
             def __repr__(self) -> str:
-                return "an instance of A"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -183,11 +183,11 @@ class TestInheritance(unittest.TestCase):
                 self.x = x
 
             def __repr__(self) -> str:
-                return "an instance of A"
+                return "an instance of {}".format(self.__class__.__name__)
 
         class B(A):
             def __repr__(self) -> str:
-                return "an instance of B"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:

--- a/tests_3_6/test_represent.py
+++ b/tests_3_6/test_represent.py
@@ -26,7 +26,11 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            'f"something" == \'\': f"something" was \'something\'',
+            textwrap.dedent(
+                """\
+                f"something" == '':
+                f"something" was 'something'
+                x was 0"""),
             tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_simple_interpolation(self) -> None:
@@ -42,7 +46,11 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            'f"{x}" == \'\': f"{x}" was \'0\'',
+            textwrap.dedent(
+                """\
+                f"{x}" == '':
+                f"{x}" was '0'
+                x was 0"""),
             tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_string_formatting(self) -> None:
@@ -58,7 +66,11 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            'f"{x!s}" == \'\': f"{x!s}" was \'1.984\'',
+            textwrap.dedent(
+                """\
+                f"{x!s}" == '':
+                f"{x!s}" was '1.984'
+                x was 1.984"""),
             tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_repr_formatting(self) -> None:
@@ -74,7 +86,11 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            'f"{x!r}" == \'\': f"{x!r}" was \'1.984\'',
+            textwrap.dedent(
+                """\
+                f"{x!r}" == '':
+                f"{x!r}" was '1.984'
+                x was 1.984"""),
             tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_ascii_formatting(self) -> None:
@@ -90,7 +106,11 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            'f"{x!a}" == \'\': f"{x!a}" was \'1.984\'',
+            textwrap.dedent(
+                """\
+                f"{x!a}" == '':
+                f"{x!a}" was '1.984'
+                x was 1.984"""),
             tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_format_spec(self) -> None:
@@ -106,7 +126,11 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            'f"{x:.3}" == \'\': f"{x:.3}" was \'1.98\'',
+            textwrap.dedent(
+                """\
+                f"{x:.3}" == '':
+                f"{x:.3}" was '1.98'
+                x was 1.984"""),
             tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_conversion_and_format_spec(self) -> None:
@@ -122,7 +146,11 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            'f"{x!r:.3}" == \'\': f"{x!r:.3}" was \'1.9\'',
+            textwrap.dedent(
+                """\
+                f"{x!r:.3}" == '':
+                f"{x!r:.3}" was '1.9'
+                x was 1.984"""),
             tests.error.wo_mandatory_location(str(violation_err)))
 
 

--- a/tests_3_8/async/test_args_and_kwargs_in_contract.py
+++ b/tests_3_8/async/test_args_and_kwargs_in_contract.py
@@ -98,6 +98,7 @@ class TestArgs(unittest.IsolatedAsyncioTestCase):
             textwrap.dedent('''\
                 len(_ARGS) > 2:
                 _ARGS was (3,)
+                args was 3
                 len(_ARGS) was 1'''), tests.error.wo_mandatory_location(str(violation_error)))
 
 
@@ -183,8 +184,10 @@ class TestKwargs(unittest.IsolatedAsyncioTestCase):
 
         assert violation_error is not None
         self.assertEqual(
-            textwrap.dedent("'x' in _KWARGS: _KWARGS was {'y': 3}"),
-            tests.error.wo_mandatory_location(str(violation_error)))
+            textwrap.dedent("""\
+                'x' in _KWARGS:
+                _KWARGS was {'y': 3}
+                y was 3"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestArgsAndKwargs(unittest.IsolatedAsyncioTestCase):

--- a/tests_3_8/test_error.py
+++ b/tests_3_8/test_error.py
@@ -1,0 +1,40 @@
+# pylint: disable=missing-docstring
+# pylint: disable=invalid-name
+# pylint: disable=unused-argument
+# pylint: disable=no-member
+# pylint: disable=no-self-use
+# pylint: disable=unused-variable
+
+import textwrap
+import unittest
+from typing import Optional
+
+import icontract
+
+import tests.error
+
+
+class TestNoneSpecified(unittest.TestCase):
+    def test_that_original_call_arguments_do_not_shadow_condition_variables_in_the_generated_message(self) -> None:
+        # ``y`` in the condition shadows the ``y`` in the arguments, but the condition lambda does not refer to
+        # the original ``y``.
+        @icontract.require(lambda x: (y := x + 3, x > 0)[1])
+        def some_func(x: int, y: int) -> None:
+            pass
+
+        violation_error = None  # type: Optional[icontract.ViolationError]
+        try:
+            some_func(x=-1, y=-1000)
+        except icontract.ViolationError as err:
+            violation_error = err
+
+        assert violation_error is not None
+        self.assertEqual(
+            textwrap.dedent("""\
+                (y := x + 3, x > 0)[1]:
+                x was -1
+                y was 2"""), tests.error.wo_mandatory_location(str(violation_error)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The previous fix, #214, actually did not resolve the issue, but the
missing effects went unnoticed due to omitted closer inspection of unit
tests.

Eventually it became apparent that the #214 was buggy. This is a
post-fix of #214 followed by a closer inspection and adaptation
of unit tests.