### PR TITLE
Unified text comparisons in tests with `textwrap`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -204,14 +204,14 @@ The script is also available as a `repl.it post`_.
     ...         self.x = -1
     ...
     ...     def __repr__(self) -> str:
-    ...         return "some instance"
+    ...         return "an instance of SomeClass"
     ...
     >>> some_instance = SomeClass()
     Traceback (most recent call last):
      ...
     icontract.errors.ViolationError: File <doctest README.rst[16]>, line 1 in <module>:
     self.x > 0:
-    self was some instance
+    self was an instance of SomeClass
     self.x was -1
 
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -143,14 +143,14 @@ After the initialization:
         ...         self.x = -1
         ...
         ...     def __repr__(self) -> str:
-        ...         return "some instance"
+        ...         return "an instance of SomeClass"
         ...
         >>> some_instance = SomeClass()
         Traceback (most recent call last):
          ...
         icontract.errors.ViolationError: File <doctest usage.rst[14]>, line 1 in <module>:
         self.x > 0:
-        self was some instance
+        self was an instance of SomeClass
         self.x was -1
 
 
@@ -167,7 +167,7 @@ Before the invocation of a public method:
     ...         self.x = 10
     ...
     ...     def __repr__(self) -> str:
-    ...         return "some instance"
+    ...         return "an instance of SomeClass"
     ...
     >>> some_instance = SomeClass()
     >>> some_instance.x = -1
@@ -176,7 +176,7 @@ Before the invocation of a public method:
      ...
     icontract.errors.ViolationError: File <doctest usage.rst[16]>, line 1 in <module>:
     self.x > 0:
-    self was some instance
+    self was an instance of SomeClass
     self.x was -1
 
 
@@ -193,7 +193,7 @@ After the invocation of a public method:
     ...         self.x = -1
     ...
     ...     def __repr__(self) -> str:
-    ...         return "some instance"
+    ...         return "an instance of SomeClass"
     ...
     >>> some_instance = SomeClass()
     >>> some_instance.some_method()
@@ -201,7 +201,7 @@ After the invocation of a public method:
      ...
     icontract.errors.ViolationError: File <doctest usage.rst[20]>, line 1 in <module>:
     self.x > 0:
-    self was some instance
+    self was an instance of SomeClass
     self.x was -1
 
 
@@ -218,7 +218,7 @@ After the invocation of a magic method:
     ...         self.x = -1
     ...
     ...     def __repr__(self) -> str:
-    ...         return "some instance"
+    ...         return "an instance of SomeClass"
     ...
     >>> some_instance = SomeClass()
     >>> some_instance()
@@ -226,7 +226,7 @@ After the invocation of a magic method:
      ...
     icontract.errors.ViolationError: File <doctest usage.rst[23]>, line 1 in <module>:
     self.x > 0:
-    self was some instance
+    self was an instance of SomeClass
     self.x was -1
 
 Snapshots (a.k.a "old" argument values)

--- a/tests/test_inheritance_invariant.py
+++ b/tests/test_inheritance_invariant.py
@@ -70,9 +70,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was instance of B\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was instance of B
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inherited_violated_in_child(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -101,9 +103,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was instance of B\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was instance of B
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_additional_invariant_violated_in_childs_init(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -112,12 +116,12 @@ class TestViolation(unittest.TestCase):
                 self.x = 10
 
             def __repr__(self) -> str:
-                return "instance of A"
+                return "an instance of A"
 
         @icontract.invariant(lambda self: self.x > 100)
         class B(A):
             def __repr__(self) -> str:
-                return "instance of B"
+                return "an instance of B"
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -126,9 +130,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 100:\n"
-                         "self was instance of B\n"
-                         "self.x was 10", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 100:
+                self was an instance of B
+                self.x was 10"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_method_violates_in_child(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -140,12 +146,12 @@ class TestViolation(unittest.TestCase):
                 self.x = 10
 
             def __repr__(self) -> str:
-                return "instance of A"
+                return "an instance of A"
 
         @icontract.invariant(lambda self: self.x > 100)
         class B(A):
             def __repr__(self) -> str:
-                return "instance of B"
+                return "an instance of B"
 
         b = B()
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -155,9 +161,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 100:\n"
-                         "self was instance of B\n"
-                         "self.x was 10", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 100:
+                self was an instance of B
+                self.x was 10"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_triple_inheritance(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -187,9 +195,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was instance of C\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was instance of C
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_abstract_method(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -202,14 +212,14 @@ class TestViolation(unittest.TestCase):
                 pass
 
             def __repr__(self) -> str:
-                return "instance of A"
+                return "an instance of A"
 
         class B(A):
             def func(self) -> None:
                 self.x = -1
 
             def __repr__(self) -> str:
-                return "instance of B"
+                return "an instance of B"
 
         b = B()
         violation_error = None  # type: Optional[icontract.ViolationError]
@@ -219,9 +229,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was instance of B\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of B
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestProperty(unittest.TestCase):
@@ -249,9 +261,11 @@ class TestProperty(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('not self.toggled:\n'
-                         'self was an instance of SomeClass\n'
-                         'self.toggled was True', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                not self.toggled:
+                self was an instance of SomeClass
+                self.toggled was True"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inherited_setter(self) -> None:
         @icontract.invariant(lambda self: not self.toggled)

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -278,7 +278,7 @@ class TestViolation(unittest.TestCase):
                 self.x = x
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         _ = SomeClass(x=1)
 
@@ -289,9 +289,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('self.x > 0:\n'
-                         'self was some instance\n'
-                         'self.x was 0', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of SomeClass
+                self.x was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inv_as_precondition(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -303,7 +305,7 @@ class TestViolation(unittest.TestCase):
                 self.x = 10
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -314,9 +316,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was some instance\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of SomeClass
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_method(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -328,7 +332,7 @@ class TestViolation(unittest.TestCase):
                 self.x = -1
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -338,9 +342,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was some instance\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of SomeClass
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_magic_method(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -352,7 +358,7 @@ class TestViolation(unittest.TestCase):
                 self.x = -1
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -362,9 +368,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was some instance\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of SomeClass
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_multiple_invs_first_violated(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -374,7 +382,7 @@ class TestViolation(unittest.TestCase):
                 self.x = -1
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -383,9 +391,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was some instance\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of SomeClass
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_multiple_invs_last_violated(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -395,7 +405,7 @@ class TestViolation(unittest.TestCase):
                 self.x = 100
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -404,9 +414,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x < 10:\n"
-                         "self was some instance\n"
-                         "self.x was 100", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x < 10:
+                self was an instance of SomeClass
+                self.x was 100"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inv_violated_after_pre(self) -> None:
         @icontract.invariant(lambda self: self.x > 0)
@@ -489,7 +501,7 @@ class TestViolation(unittest.TestCase):
                 return 10
 
             def __repr__(self) -> str:
-                return "some instance"
+                return "an instance of {}".format(self.__class__.__name__)
 
         violation_error = None  # type: Optional[icontract.ViolationError]
         try:
@@ -499,9 +511,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.x > 0:\n"
-                         "self was some instance\n"
-                         "self.x was -1", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.x > 0:
+                self was an instance of SomeClass
+                self.x was -1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_inv_with_empty_arguments(self) -> None:
         z = 42

--- a/tests/test_postcondition.py
+++ b/tests/test_postcondition.py
@@ -115,10 +115,12 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('some_condition:\n'
-                         'result was 1\n'
-                         'x was 1\n'
-                         'y was 3', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                some_condition:
+                result was 1
+                x was 1
+                y was 3"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_description(self) -> None:
         @icontract.ensure(lambda result, x: result > x, "expected summation")

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -79,9 +79,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("some_condition:\n"
-                         "x was 1\n"
-                         "y was 5", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                some_condition:
+                x was 1
+                y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_condition_as_function_with_default_argument_value(self) -> None:
         def some_condition(x: int, y: int = 0) -> bool:
@@ -123,9 +125,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('some_condition:\n'
-                         'x was -1\n'
-                         'y was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                some_condition:
+                x was -1
+                y was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_pathlib(self) -> None:
         @icontract.require(lambda path: path.exists())
@@ -189,9 +193,11 @@ class TestViolation(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x > another_var:\n"
-                         "another_var was 0\n"
-                         "x was 0", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x > another_var:
+                another_var was 0
+                x was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_with_default_values(self) -> None:
         @icontract.require(lambda a: a < 10)

--- a/tests/test_represent.py
+++ b/tests/test_represent.py
@@ -86,10 +86,12 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('sum([1, y, x]) == 1:\n'
-                         'sum([1, y, x]) was 5\n'
-                         'x was 3\n'
-                         'y was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                sum([1, y, x]) == 1:
+                sum([1, y, x]) was 5
+                x was 3
+                y was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_tuple(self) -> None:
         y = 1
@@ -105,10 +107,12 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('sum((1, y, x)) == 1:\n'
-                         'sum((1, y, x)) was 5\n'
-                         'x was 3\n'
-                         'y was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                sum((1, y, x)) == 1:
+                sum((1, y, x)) was 5
+                x was 3
+                y was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_set(self) -> None:
         y = 2
@@ -124,10 +128,12 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('sum({1, y, x}) == 1:\n'
-                         'sum({1, y, x}) was 6\n'
-                         'x was 3\n'
-                         'y was 2', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                sum({1, y, x}) == 1:
+                sum({1, y, x}) was 6
+                x was 3
+                y was 2"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_dict(self) -> None:
         y = "someKey"
@@ -143,10 +149,12 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("len({y: 3, x: 8}) == 6:\n"
-                         "len({y: 3, x: 8}) was 2\n"
-                         "x was 'oi'\n"
-                         "y was 'someKey'", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                len({y: 3, x: 8}) == 6:
+                len({y: 3, x: 8}) was 2
+                x was 'oi'
+                y was 'someKey'"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_unary_op(self) -> None:
         @icontract.require(lambda x: not -x + 10 > 3)
@@ -240,9 +248,11 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('0 < x < 3 and x > 10 and x != 7 and x >= 10 and x <= 11 and x is not None and\n'
-                         '              x in [1, 2, 3] and x not in [1, 2, 3]: x was 1',
-                         tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                0 < x < 3 and x > 10 and x != 7 and x >= 10 and x <= 11 and x is not None and
+                              x in [1, 2, 3] and x not in [1, 2, 3]: x was 1"""),
+            tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_call(self) -> None:
         def y() -> int:
@@ -259,7 +269,11 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('x < y():\n' 'x was 1\n' 'y() was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < y():
+                x was 1
+                y() was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_if_exp_body(self) -> None:
         y = 5
@@ -275,9 +289,11 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('x < (x**2 if y == 5 else x**3):\n'
-                         'x was 1\n'
-                         'y was 5', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < (x**2 if y == 5 else x**3):
+                x was 1
+                y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_if_exp_orelse(self) -> None:
         y = 5
@@ -293,8 +309,11 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('x < (x**2 if y != 5 else x**3):\nx was 1\ny was 5',
-                         tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < (x**2 if y != 5 else x**3):
+                x was 1
+                y was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_attr(self) -> None:
         class A:
@@ -302,7 +321,7 @@ class TestReprValues(unittest.TestCase):
                 self.y = 3
 
             def __repr__(self) -> str:
-                return "A()"
+                return "an instance of {}".format(self.__class__.__name__)
 
         a = A()
 
@@ -317,10 +336,12 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('x > a.y:\n'
-                         'a was A()\n'
-                         'a.y was 3\n'
-                         'x was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x > a.y:
+                a was an instance of A
+                a.y was 3
+                x was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_index(self) -> None:
         lst = [1, 2, 3]
@@ -336,9 +357,11 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('x > lst[1]:\n'
-                         'lst was [1, 2, 3]\n'
-                         'x was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x > lst[1]:
+                lst was [1, 2, 3]
+                x was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_slice(self) -> None:
         lst = [1, 2, 3]
@@ -354,10 +377,12 @@ class TestReprValues(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('x > sum(lst[1:2:1]):\n'
-                         'lst was [1, 2, 3]\n'
-                         'sum(lst[1:2:1]) was 2\n'
-                         'x was 1', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x > sum(lst[1:2:1]):
+                lst was [1, 2, 3]
+                sum(lst[1:2:1]) was 2
+                x was 1"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_lambda(self) -> None:
         @icontract.require(lambda x: x > (lambda y: y + 4).__call__(y=7))  # type: ignore
@@ -718,7 +743,11 @@ class TestConditionAsText(unittest.TestCase):
             violation_err = err
 
         self.assertIsNotNone(violation_err)
-        self.assertEqual('x\n    >\n    3: x was 0', tests.error.wo_mandatory_location(str(violation_err)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x
+                    >
+                    3: x was 0"""), tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_with_multiple_lambdas_on_a_line(self) -> None:
         # pylint: disable=unnecessary-lambda
@@ -770,9 +799,11 @@ class TestRepr(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("len(x) < 10:\n"
-                         "len(x) was 10000\n"
-                         "x was [0, 1, 2, ...]", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                len(x) < 10:
+                len(x) was 10000
+                x was [0, 1, 2, ...]"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestClass(unittest.TestCase):
@@ -807,10 +838,12 @@ class TestClass(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("self.b.x > 0:\n"
-                         "self was A()\n"
-                         "self.b was B(x=0)\n"
-                         "self.b.x was 0", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                self.b.x > 0:
+                self was A()
+                self.b was B(x=0)
+                self.b.x was 0"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_nested_method(self) -> None:
         z = 10
@@ -888,10 +921,12 @@ class TestClosures(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x < y + z:\n"
-                         "x was 100\n"
-                         "y was 4\n"
-                         "z was 5", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < y + z:
+                x was 100
+                y was 4
+                z was 5"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_global(self) -> None:
         @icontract.require(lambda x: x < SOME_GLOBAL_CONSTANT)
@@ -905,9 +940,11 @@ class TestClosures(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x < SOME_GLOBAL_CONSTANT:\n"
-                         "SOME_GLOBAL_CONSTANT was 10\n"
-                         "x was 100", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < SOME_GLOBAL_CONSTANT:
+                SOME_GLOBAL_CONSTANT was 10
+                x was 100"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_closure_and_global(self) -> None:
         y = 4
@@ -923,10 +960,12 @@ class TestClosures(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual("x < y + SOME_GLOBAL_CONSTANT:\n"
-                         "SOME_GLOBAL_CONSTANT was 10\n"
-                         "x was 100\n"
-                         "y was 4", tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                x < y + SOME_GLOBAL_CONSTANT:
+                SOME_GLOBAL_CONSTANT was 10
+                x was 100
+                y was 4"""), tests.error.wo_mandatory_location(str(violation_error)))
 
 
 class TestWithNumpyMock(unittest.TestCase):
@@ -954,9 +993,11 @@ class TestWithNumpyMock(unittest.TestCase):
             violation_error = err
 
         self.assertIsNotNone(violation_error)
-        self.assertEqual('(arr > 0).all():\n'
-                         '(arr > 0).all() was False\n'
-                         'arr was NumpyArray([-3, 3])', tests.error.wo_mandatory_location(str(violation_error)))
+        self.assertEqual(
+            textwrap.dedent("""\
+                (arr > 0).all():
+                (arr > 0).all() was False
+                arr was NumpyArray([-3, 3])"""), tests.error.wo_mandatory_location(str(violation_error)))
 
     def test_that_multiple_comparators_fail(self) -> None:
         """


### PR DESCRIPTION
This patch makes all the unit tests use `textwrap` for easier
readability when we compare multi-line texts.

This should also provide a hint to the developers in the future how to
deal with multi-line texts.