### PR TITLE
Released 2.5.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.5.3
+=====
+* Fixed reporting all arguments on violation (#219)
+* Propagated placeholders in re-computation (#218)
+* Fixed docstring for ``collect_variable_lookup`` (#217)
+
 2.5.2
 =====
 * Fixed handling of ``self`` when passed as kwarg (#213)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = '2.5.2'
+__version__ = '2.5.3'
 __author__ = 'Marko Ristin'
 __copyright__ = 'Copyright 2019 Parquery AG'
 __license__ = 'MIT'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 setup(
     name='icontract',
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version='2.5.2',
+    version='2.5.3',
     description='Provide design-by-contract with informative violation messages.',
     long_description=long_description,
     url='https://github.com/Parquery/icontract',


### PR DESCRIPTION
* Fixed reporting all arguments on violation (#219)
* Propagated placeholders in re-computation (#218)
* Fixed docstring for `collect_variable_lookup` (#217)