### PR TITLE
Upgraded to mypy 0.910

### DIFF
--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -996,8 +996,8 @@ def add_invariant_checks(cls: type) -> None:
 
     for name, prop in names_properties:
         new_prop = property(
-            fget=_decorate_with_invariants(func=prop.fget, is_init=False) if prop.fget else None,  # type: ignore
-            fset=_decorate_with_invariants(func=prop.fset, is_init=False) if prop.fset else None,  # type: ignore
-            fdel=_decorate_with_invariants(func=prop.fdel, is_init=False) if prop.fdel else None,  # type: ignore
+            fget=_decorate_with_invariants(func=prop.fget, is_init=False) if prop.fget else None,
+            fset=_decorate_with_invariants(func=prop.fset, is_init=False) if prop.fset else None,
+            fdel=_decorate_with_invariants(func=prop.fdel, is_init=False) if prop.fdel else None,
             doc=prop.__doc__)
         setattr(cls, name, new_prop)

--- a/icontract/_metaclass.py
+++ b/icontract/_metaclass.py
@@ -9,8 +9,8 @@ from typing import List, MutableMapping, Any, Callable, Optional, cast, Set, Typ
 from icontract._types import Contract, Snapshot
 import icontract._checkers
 
-# Pylint can't deal with multiple Python versions.
-# pylint: disable=arguments-differ
+# Pylint can't deal with multiple Python versions and breaks on ``if``'s on method definitions.
+# pylint: skip-file
 
 
 def _collapse_invariants(bases: List[type], namespace: MutableMapping[str, Any]) -> None:
@@ -226,9 +226,9 @@ def _decorate_namespace_property(bases: List[type], namespace: MutableMapping[st
 
         contract_checker = icontract._checkers.find_checker(func=func)
         if contract_checker is not None:
-            preconditions = contract_checker.__preconditions__
-            snapshots = contract_checker.__postcondition_snapshots__
-            postconditions = contract_checker.__postconditions__
+            preconditions = contract_checker.__preconditions__  # type: ignore
+            snapshots = contract_checker.__postcondition_snapshots__  # type: ignore
+            postconditions = contract_checker.__postconditions__  # type: ignore
 
         preconditions = _collapse_preconditions(
             base_preconditions=base_preconditions,
@@ -256,9 +256,9 @@ def _decorate_namespace_property(bases: List[type], namespace: MutableMapping[st
                     raise NotImplementedError("Unhandled case: func neither fget, fset nor fdel")
 
             # Override the preconditions and postconditions
-            contract_checker.__preconditions__ = preconditions
-            contract_checker.__postcondition_snapshots__ = snapshots
-            contract_checker.__postconditions__ = postconditions
+            contract_checker.__preconditions__ = preconditions  # type: ignore
+            contract_checker.__postcondition_snapshots__ = snapshots  # type: ignore
+            contract_checker.__postconditions__ = postconditions  # type: ignore
 
     if fget != value.fget or fset != value.fset or fdel != value.fdel:
         namespace[key] = property(fget=fget, fset=fset, fdel=fdel)
@@ -335,7 +335,7 @@ class DBCMeta(abc.ABCMeta):
             # This usually works since icontract-hypothesis does not use DBCMeta,
             # but blows up since icontract creates DBC with DBCMeta meta-class at the import time.
             if cls.__module__ != __name__:
-                _register_for_hypothesis(cls)
+                _register_for_hypothesis(cls)  # type: ignore
 
             return cls
     else:
@@ -344,7 +344,7 @@ class DBCMeta(abc.ABCMeta):
             """Create a class with inherited preconditions, postconditions and invariants."""
             _dbc_decorate_namespace(bases, namespace)
 
-            cls = super().__new__(mlcs, name, bases, namespace, **kwargs)  # type: ignore
+            cls = super().__new__(mlcs, name, bases, namespace, **kwargs)
 
             if hasattr(cls, "__invariants__"):
                 icontract._checkers.add_invariant_checks(cls=cls)
@@ -354,7 +354,7 @@ class DBCMeta(abc.ABCMeta):
             # This usually works since icontract-hypothesis does not use DBCMeta,
             # but blows up since icontract creates DBC with DBCMeta meta-class at the import time.
             if cls.__module__ != __name__:
-                _register_for_hypothesis(cls)
+                _register_for_hypothesis(cls)  # type: ignore
 
             return cls
 

--- a/icontract/_recompute.py
+++ b/icontract/_recompute.py
@@ -239,7 +239,6 @@ class Visitor(ast.NodeVisitor):
         # value assigned to each visited node
         self.recomputed_values = dict()  # type: Dict[ast.AST, Any]
 
-    # pylint: disable=no-member
     if sys.version_info < (3, 8):
 
         def visit_Num(self, node: ast.Num) -> Union[int, float]:
@@ -327,8 +326,6 @@ class Visitor(ast.NodeVisitor):
 
             self.recomputed_values[node] = joined_str
             return joined_str
-
-    # pylint: enable=no-member
 
     def visit_List(self, node: ast.List) -> Union[List[Any], Placeholder]:
         """Visit the elements and assemble the results into a list."""
@@ -644,7 +641,7 @@ class Visitor(ast.NodeVisitor):
         return result
 
     if sys.version_info >= (3, 8):
-        # pylint: disable=no-member
+
         def visit_NamedExpr(self, node: ast.NamedExpr) -> Any:
             """Visit the node's ``value`` and assign it to both this node and the target."""
             value = self.visit(node=node.value)

--- a/icontract/_represent.py
+++ b/icontract/_represent.py
@@ -55,7 +55,7 @@ class Visitor(ast.NodeVisitor):
         self._atok = atok
 
     if sys.version_info >= (3, 6):
-        # pylint: disable=no-member
+
         def visit_JoinedStr(self, node: ast.JoinedStr) -> None:
             """Show the whole joined strings without descending into the values."""
             if node in self._recomputed_values:
@@ -100,7 +100,7 @@ class Visitor(ast.NodeVisitor):
         self.generic_visit(node=node)
 
     if sys.version_info >= (3, 8):
-        # pylint: disable=no-member
+
         def visit_NamedExpr(self, node: ast.NamedExpr) -> Any:
             """Represent the target with the value of the node."""
             if node in self._recomputed_values:

--- a/pylint.rc
+++ b/pylint.rc
@@ -7,5 +7,5 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,duplicate-code,no-else-raise,too-many-locals,too-many-branches,too-many-lines,too-many-arguments,too-many-statements,too-many-nested-blocks,too-many-function-args,too-many-instance-attributes,too-many-public-methods,protected-access,consider-using-in
+disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,duplicate-code,no-else-raise,too-many-locals,too-many-branches,too-many-lines,too-many-arguments,too-many-statements,too-many-nested-blocks,too-many-function-args,too-many-instance-attributes,too-many-public-methods,protected-access,consider-using-in,no-member
 

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     # yapf: disable
     extras_require={
         'dev': [
-            'mypy==0.812', 'pylint==2.3.1', 'yapf==0.20.2', 'tox>=3.0.0', 'pydocstyle>=2.1.1,<3', 'coverage>=4.5.1,<5',
+            'mypy==0.910', 'pylint==2.9.6', 'yapf==0.20.2', 'tox>=3.0.0', 'pydocstyle>=2.1.1,<3', 'coverage>=4.5.1,<5',
             'docutils>=0.14,<1', 'pygments>=2.2.0,<3', 'dpcontracts==0.6.0', 'tabulate>=0.8.7,<1',
             'py-cpuinfo>=5.0.0,<6', 'typeguard>=2,<3', 'astor==0.8.1'
         ] + (['deal==4.1.0'] if sys.version_info >= (3, 8) else []) + (['asyncstdlib==3.9.1']

--- a/tests/test_args_and_kwargs_in_contract.py
+++ b/tests/test_args_and_kwargs_in_contract.py
@@ -2,7 +2,6 @@
 # pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-member
 # pylint: disable=unnecessary-lambda
 # pylint: disable=unused-variable
 

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-member
 # pylint: disable=no-self-use
 # pylint: disable=unused-variable
 

--- a/tests/test_for_integrators.py
+++ b/tests/test_for_integrators.py
@@ -1,7 +1,7 @@
 """Test logic that can be potentially used by the integrators such as third-party libraries."""
 
 # pylint: disable=no-self-use,missing-docstring
-# pylint: disable=invalid-name,unnecessary-lambda,no-member
+# pylint: disable=invalid-name,unnecessary-lambda
 
 import ast
 import unittest

--- a/tests/test_inheritance_invariant.py
+++ b/tests/test_inheritance_invariant.py
@@ -1,7 +1,6 @@
 # pylint: disable=invalid-name
 # pylint: disable=missing-docstring
 # pylint: disable=unused-argument
-# pylint: disable=no-member
 
 import abc
 import textwrap

--- a/tests/test_inheritance_postcondition.py
+++ b/tests/test_inheritance_postcondition.py
@@ -225,7 +225,7 @@ class TestViolation(unittest.TestCase):
             def __repr__(self) -> str:
                 return "an instance of {}".format(self.__class__.__name__)
 
-        violation_error = None  # Optional[icontract.ViolationError]
+        violation_error = None  # type: Optional[icontract.ViolationError]
         try:
             _ = B(x=-1)
         except icontract.ViolationError as err:
@@ -357,7 +357,6 @@ class TestPropertyViolation(unittest.TestCase):
                 pass
 
         class SomeClass(SomeBase):
-            # pylint: disable=no-member
             @SomeBase.some_prop.setter  # type: ignore
             def some_prop(self, value: int) -> None:
                 pass
@@ -400,7 +399,6 @@ class TestPropertyViolation(unittest.TestCase):
             def __repr__(self) -> str:
                 return "an instance of {}".format(self.__class__.__name__)
 
-            # pylint: disable=no-member
             @SomeBase.some_prop.deleter  # type: ignore
             def some_prop(self) -> None:
                 pass
@@ -435,7 +433,6 @@ class TestPropertyViolation(unittest.TestCase):
                 pass
 
         class SomeClass(SomeBase):
-            # pylint: disable=no-member
             @SomeBase.some_prop.setter  # type: ignore
             @icontract.ensure(lambda self: not self.toggled)
             def some_prop(self, value: int) -> None:

--- a/tests/test_inheritance_precondition.py
+++ b/tests/test_inheritance_precondition.py
@@ -382,7 +382,6 @@ class TestPropertyViolation(unittest.TestCase):
                 pass
 
         class SomeClass(SomeBase):
-            # pylint: disable=no-member
             @SomeBase.some_prop.setter  # type: ignore
             def some_prop(self, value: int) -> None:
                 pass
@@ -423,7 +422,6 @@ class TestPropertyViolation(unittest.TestCase):
             def __repr__(self) -> str:
                 return "an instance of {}".format(self.__class__.__name__)
 
-            # pylint: disable=no-member
             @SomeBase.some_prop.deleter  # type: ignore
             def some_prop(self) -> None:
                 pass

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-member
 import textwrap
 import time
 import unittest

--- a/tests/test_mypy_decorators.py
+++ b/tests/test_mypy_decorators.py
@@ -33,18 +33,19 @@ class TestMypyDecorators(unittest.TestCase):
             pth = pathlib.Path(tmpdir) / "source.py"
             pth.write_text(content)
 
-            proc = subprocess.Popen(['mypy', '--strict', str(pth)], universal_newlines=True, stdout=subprocess.PIPE)
-            out, err = proc.communicate()
+            with subprocess.Popen(
+                ['mypy', '--strict', str(pth)], universal_newlines=True, stdout=subprocess.PIPE) as proc:
+                out, err = proc.communicate()
 
-            self.assertIsNone(err)
-            self.assertEqual(
-                textwrap.dedent('''\
-                    {path}:8: error: Argument 1 to "f1" has incompatible type "str"; expected "int"
-                    {path}:13: error: Argument 1 to "f2" has incompatible type "str"; expected "int"
-                    {path}:18: error: Argument 1 to "f3" has incompatible type "str"; expected "int"
-                    Found 3 errors in 1 file (checked 1 source file)
-                    '''.format(path=pth)),
-                out)
+                self.assertIsNone(err)
+                self.assertEqual(
+                    textwrap.dedent('''\
+                        {path}:8: error: Argument 1 to "f1" has incompatible type "str"; expected "int"
+                        {path}:13: error: Argument 1 to "f2" has incompatible type "str"; expected "int"
+                        {path}:18: error: Argument 1 to "f3" has incompatible type "str"; expected "int"
+                        Found 3 errors in 1 file (checked 1 source file)
+                        '''.format(path=pth)),
+                    out)
 
 
 if __name__ == '__main__':

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -161,7 +161,7 @@ class TestInvariant(unittest.TestCase):
     def test_ok(self) -> None:
         order = []  # type: List[str]
 
-        @icontract.invariant(lambda self: self.some_func())  # pylint: disable=no-member
+        @icontract.invariant(lambda self: self.some_func())
         class SomeClass(icontract.DBC):
             def __init__(self) -> None:
                 order.append('__init__')
@@ -190,7 +190,7 @@ class TestInvariant(unittest.TestCase):
         class CustomError(Exception):
             pass
 
-        @icontract.invariant(lambda self: self.some_func())  # pylint: disable=no-member
+        @icontract.invariant(lambda self: self.some_func())
         class SomeClass(icontract.DBC):
             def __init__(self) -> None:
                 order.append('__init__')
@@ -230,7 +230,7 @@ class TestInvariant(unittest.TestCase):
     def test_member_function_call_in_constructor(self) -> None:
         order = []  # type: List[str]
 
-        @icontract.invariant(lambda self: self.some_attribute > 0)  # pylint: disable=no-member
+        @icontract.invariant(lambda self: self.some_attribute > 0)
         class SomeClass(icontract.DBC):
             def __init__(self) -> None:
                 order.append('__init__ enters')

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -2,7 +2,6 @@
 # pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-member
 
 import textwrap
 import unittest

--- a/tests_3_7/test_invariant.py
+++ b/tests_3_7/test_invariant.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-member
+
 import dataclasses
 import textwrap
 import unittest

--- a/tests_3_8/async/test_args_and_kwargs_in_contract.py
+++ b/tests_3_8/async/test_args_and_kwargs_in_contract.py
@@ -2,7 +2,6 @@
 # pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-member
 # pylint: disable=unnecessary-lambda
 import copy
 import textwrap

--- a/tests_3_8/async/test_exceptions.py
+++ b/tests_3_8/async/test_exceptions.py
@@ -1,7 +1,7 @@
 # The module ``unittest`` supports async only from 3.8 on.
 # That is why we had to move this test to 3.8 specific tests.
 
-# pylint: disable=missing-docstring, invalid-name, no-member, unnecessary-lambda
+# pylint: disable=missing-docstring, invalid-name, unnecessary-lambda
 import unittest
 from typing import Optional, List
 

--- a/tests_3_8/async/test_invariant.py
+++ b/tests_3_8/async/test_invariant.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
-# pylint: disable=no-member
 
 import unittest
 from typing import Optional

--- a/tests_3_8/async/test_postcondition.py
+++ b/tests_3_8/async/test_postcondition.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
-# pylint: disable=no-member
 # pylint: disable=unused-argument
 # pylint: disable=unnecessary-lambda
 

--- a/tests_3_8/async/test_precondition.py
+++ b/tests_3_8/async/test_precondition.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
-# pylint: disable=no-member
 # pylint: disable=unused-argument
 # pylint: disable=unnecessary-lambda
 

--- a/tests_3_8/test_error.py
+++ b/tests_3_8/test_error.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-member
 # pylint: disable=no-self-use
 # pylint: disable=unused-variable
 

--- a/tests_3_8/test_invariant.py
+++ b/tests_3_8/test_invariant.py
@@ -1,7 +1,7 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-member
+
 import textwrap
 import unittest
 from typing import NamedTuple, Optional  # pylint: disable=unused-import


### PR DESCRIPTION
Upgraded to mypy 0.910 and pylint 2.9.6

This patch upgrades the mypy to 0.910. This was necessary so that we can
test the type inference with the latest mypy.

We also had to upgrade pylint 2.9.6 since the checks broke on CI due to
astroid having hard time parsing `_metaclass.py`. Due to this upgrade,
we had to disable all `no-member` warnings from pylint as pylint did not
properly infer types in condition functions.

Related to #224.
