### PR TITLE
Made invariant type annotation more specific

### DIFF
--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -6,7 +6,7 @@ from typing import Callable, Any, Iterable, Optional, Tuple, List, Mapping, \
     MutableMapping, Dict, cast
 
 import icontract._represent
-from icontract._globals import CallableT
+from icontract._globals import CallableT, ClassT
 from icontract._types import Contract, Snapshot
 from icontract.errors import ViolationError
 
@@ -924,7 +924,7 @@ def _already_decorated_with_invariants(func: CallableT) -> bool:
     return already_decorated
 
 
-def add_invariant_checks(cls: type) -> None:
+def add_invariant_checks(cls: ClassT) -> None:
     """Decorate each of the class functions with invariant checks if not already decorated."""
     # Candidates for the decoration as list of (name, dir() value)
     init_name_func = None  # type: Optional[Tuple[str, Callable[..., None]]]

--- a/icontract/_decorators.py
+++ b/icontract/_decorators.py
@@ -2,10 +2,10 @@
 import inspect
 import reprlib
 import traceback
-from typing import Callable, Optional, Union, Any, List, Type  # pylint: disable=unused-import
+from typing import Callable, Optional, Union, Any, List, Type, TypeVar  # pylint: disable=unused-import
 
 import icontract._checkers
-from icontract._globals import CallableT, ExceptionT
+from icontract._globals import CallableT, ExceptionT, ClassT
 from icontract._types import Contract, Snapshot
 
 
@@ -353,7 +353,7 @@ class invariant:  # pylint: disable=invalid-name
             raise ValueError("Expected an invariant condition with at most an argument 'self', but got: {}".format(
                 self._contract.condition_args))
 
-    def __call__(self, cls: type) -> type:
+    def __call__(self, cls: ClassT) -> ClassT:
         """
         Decorate each of the public methods with the invariant.
 

--- a/icontract/_globals.py
+++ b/icontract/_globals.py
@@ -28,4 +28,5 @@ aRepr.maxother = 256
 # Contracts marked with SLOW are also disabled if the interpreter is run in optimized mode (``-O`` or ``-OO``).
 SLOW = __debug__ and os.environ.get("ICONTRACT_SLOW", "") != ""
 CallableT = TypeVar('CallableT', bound=Callable[..., Any])
+ClassT = TypeVar('ClassT', bound=type)
 ExceptionT = TypeVar('ExceptionT', bound=BaseException)


### PR DESCRIPTION
The current type annotation of the `invariant` decorator did not use
generics. This patch makes it more specific so that a generic
``TypeVar`` bounded by ``type`` is used in order to help downstream
tools work better.

Related to #224.