### PR TITLE
Removed tag for Python 3.5

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,6 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8'


### PR DESCRIPTION
Python 3.5 could not be supported since neither mypy nor pylint support
Python 3.5 anymore. Python 3.5 reached end-of-life in 2020, so more
dependencies are probably affected as well.

This change simply removes the corresponding tag in the distribution.
The continous integration only tested for >= 3.6 Python versions anyhow.