### PR TITLE
Released 2.5.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,8 @@
+2.5.5
+=====
+* Fixed representation of numpy arrays (#232)
+* Removed tag for Python 3.5 (#231)
+
 2.5.4
 =====
 * Made type annotation for ``invariant`` decorator more specific (#227)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = '2.5.4'
+__version__ = '2.5.5'
 __author__ = 'Marko Ristin'
 __copyright__ = 'Copyright 2019 Parquery AG'
 __license__ = 'MIT'

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
 setup(
     name='icontract',
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version='2.5.4',
+    version='2.5.5',
     description='Provide design-by-contract with informative violation messages.',
     long_description=long_description,
     url='https://github.com/Parquery/icontract',


### PR DESCRIPTION
* Fixed representation of numpy arrays (#232)
* Removed tag for Python 3.5 (#231)