### PR TITLE
Added support for Python 3.9 and 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10']
 
     steps:
       - uses: actions/checkout@master

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
-venv3/
-venv/
+venv*/
 .mypy_cache/
 .idea/
 *.pyc

--- a/icontract/_metaclass.py
+++ b/icontract/_metaclass.py
@@ -1,7 +1,7 @@
 """Define the metaclass necessary to inherit the contracts from the base classes."""
 import abc
 import inspect
-import platform
+import sys
 import weakref
 from typing import List, MutableMapping, Any, Callable, Optional, cast, Set, Type, \
     TypeVar  # pylint: disable=unused-import
@@ -316,12 +316,12 @@ class DBCMeta(abc.ABCMeta):
     # instead of ``mcs``.
     # pylint: disable=bad-mcs-classmethod-argument
 
-    if platform.python_version_tuple() < ('3', ):
-        raise NotImplementedError("Python versions below not supported, got: {}".format(platform.python_version()))
+    if sys.version_info < (3, ):
+        raise NotImplementedError("Python versions below not supported, got: {}".format(sys.version_info))
 
-    if platform.python_version_tuple() <= ('3', '5'):
+    if sys.version_info < (3, 6):
         # pylint: disable=arguments-differ
-        def __new__(mlcs, name, bases, namespace):  # type: ignore
+        def __new__(mlcs, name, bases, namespace):
             """Create a class with inherited preconditions, postconditions and invariants."""
             _dbc_decorate_namespace(bases, namespace)
 
@@ -335,7 +335,7 @@ class DBCMeta(abc.ABCMeta):
             # This usually works since icontract-hypothesis does not use DBCMeta,
             # but blows up since icontract creates DBC with DBCMeta meta-class at the import time.
             if cls.__module__ != __name__:
-                _register_for_hypothesis(cls)  # type: ignore
+                _register_for_hypothesis(cls)
 
             return cls
     else:

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,9 @@ setup(
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8'
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10'
         # yapf: enable
     ],
     license='License :: OSI Approved :: MIT License',
@@ -50,7 +52,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'dev': [
-            'mypy==0.910', 'pylint==2.9.6', 'yapf==0.20.2', 'tox>=3.0.0', 'pydocstyle>=2.1.1,<3', 'coverage>=4.5.1,<5',
+            'mypy==0.910', 'pylint==2.9.6', 'yapf==0.20.2', 'tox>=3.0.0', 'pydocstyle>=6.1.1,<7', 'coverage>=4.5.1,<5',
             'docutils>=0.14,<1', 'pygments>=2.2.0,<3', 'dpcontracts==0.6.0', 'tabulate>=0.8.7,<1',
             'py-cpuinfo>=5.0.0,<6', 'typeguard>=2,<3', 'astor==0.8.1', 'numpy>=1,<2'
         ] + (['deal==4.1.0'] if sys.version_info >= (3, 8) else []) + (['asyncstdlib==3.9.1']

--- a/tests/test_checkers.py
+++ b/tests/test_checkers.py
@@ -66,7 +66,8 @@ class TestResolveKwargs(unittest.TestCase):
             type_error = error
 
         assert type_error is not None
-        self.assertEqual("some_func() takes 2 positional arguments but 3 were given", str(type_error))
+        self.assertRegex(
+            str(type_error), r"^([a-zA-Z_0-9<>.]+\.)?some_func\(\) takes 2 positional arguments but 3 were given$")
 
     def test_that_result_in_kwargs_raises_an_error(self) -> None:
         @icontract.ensure(lambda result: result > 0)

--- a/tests/test_inheritance_postcondition.py
+++ b/tests/test_inheritance_postcondition.py
@@ -3,6 +3,7 @@
 # pylint: disable=no-self-use
 
 import abc
+import sys
 import textwrap
 import unittest
 from typing import Optional  # pylint: disable=unused-import
@@ -478,7 +479,10 @@ class TestInvalid(unittest.TestCase):
             type_err = err
 
         self.assertIsNotNone(type_err)
-        self.assertEqual("Can't instantiate abstract class B with abstract methods func", str(type_err))
+        if sys.version_info < (3, 9):
+            self.assertEqual("Can't instantiate abstract class B with abstract methods func", str(type_err))
+        else:
+            self.assertEqual("Can't instantiate abstract class B with abstract method func", str(type_err))
 
 
 if __name__ == '__main__':

--- a/tests/test_inheritance_precondition.py
+++ b/tests/test_inheritance_precondition.py
@@ -3,6 +3,7 @@
 # pylint: disable=no-self-use
 
 import abc
+import sys
 import textwrap
 import unittest
 from typing import Optional, Sequence, cast  # pylint: disable=unused-import
@@ -526,7 +527,10 @@ class TestInvalid(unittest.TestCase):
             type_err = err
 
         self.assertIsNotNone(type_err)
-        self.assertEqual("Can't instantiate abstract class B with abstract methods func", str(type_err))
+        if sys.version_info < (3, 9):
+            self.assertEqual("Can't instantiate abstract class B with abstract methods func", str(type_err))
+        else:
+            self.assertEqual("Can't instantiate abstract class B with abstract method func", str(type_err))
 
     def test_cant_weaken_base_function_without_preconditions(self) -> None:
         class A(icontract.DBC):

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -9,7 +9,7 @@ import pathlib
 import textwrap
 import time
 import unittest
-from typing import Optional, Callable, Any  # pylint: disable=unused-import
+from typing import Optional  # pylint: disable=unused-import
 
 import icontract
 from icontract._globals import CallableT
@@ -611,7 +611,8 @@ class TestInvalid(unittest.TestCase):
             type_error = err
 
         self.assertIsNotNone(type_error)
-        self.assertEqual('some_func() takes 0 positional arguments but 1 was given', str(type_error))
+        self.assertRegex(
+            str(type_error), r'^([a-zA-Z_0-9<>.]+\.)?some_func\(\) takes 0 positional arguments but 1 was given$')
 
     def test_unexpected_keyword_argument(self) -> None:
         @icontract.require(lambda: True)
@@ -626,7 +627,8 @@ class TestInvalid(unittest.TestCase):
             type_error = err
 
         self.assertIsNotNone(type_error)
-        self.assertEqual("some_func() got an unexpected keyword argument 'x'", str(type_error))
+        self.assertRegex(
+            str(type_error), r"^([a-zA-Z_0-9<>.]+\.)?some_func\(\) got an unexpected keyword argument 'x'$")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This patch introduces Python versions 3.9 and 3.10 in continuous
integration as well as minor fixes caused by the deprecations in
these new versions.

Also fixes #235.