### PR TITLE
Added representation of subscripts

### DIFF
--- a/icontract/_recompute.py
+++ b/icontract/_recompute.py
@@ -718,7 +718,6 @@ class Visitor(ast.NodeVisitor):
             return PLACEHOLDER
 
         result = value[a_slice]
-
         self.recomputed_values[node] = result
         return result
 

--- a/icontract/_represent.py
+++ b/icontract/_represent.py
@@ -154,6 +154,16 @@ class Visitor(ast.NodeVisitor):
 
         self.generic_visit(node=node)
 
+    def visit_Subscript(self, node: ast.Subscript) -> None:
+        """Represent the subscript with its source code."""
+        if node in self._recomputed_values:
+            value = self._recomputed_values[node]
+            text = self._atok.get_text(node)
+
+            self.reprs[text] = value
+
+        self.generic_visit(node=node)
+
 
 def is_lambda(a_function: CallableT) -> bool:
     """

--- a/tests_3_8/test_error.py
+++ b/tests_3_8/test_error.py
@@ -31,6 +31,7 @@ class TestNoneSpecified(unittest.TestCase):
         self.assertEqual(
             textwrap.dedent("""\
                 (y := x + 3, x > 0)[1]:
+                (y := x + 3, x > 0)[1] was False
                 x was -1
                 y was 2"""), tests.error.wo_mandatory_location(str(violation_error)))
 


### PR DESCRIPTION
With this patch, whenever a contract violation occurs, the subscripts
(such as `arr[x]`) will be included in the error message.