### PR TITLE
Excluded all tests from package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ setup(
     ],
     license='License :: OSI Approved :: MIT License',
     keywords='design-by-contract precondition postcondition validation',
-    packages=find_packages(exclude=['tests']),
+    packages=find_packages(exclude=['tests*']),
     install_requires=install_requires,
     extras_require={
         'dev': [


### PR DESCRIPTION
The test directories `tests_*` are erronously included in the package. With this patch they are excluded in the package building.

Fixes #239.