### PR TITLE
Fixed typos in documentation

### DIFF
--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -76,7 +76,7 @@ Note that neither the `dpcontracts` nor the `deal` library support recursion and
 This allows them to use faster enforcement mechanisms and thus gain a speed-up.
 
 We also ran a much more extensive battery of benchmarks on icontract 2.0.7. Unfortunately,
-it would cost us too much effort to integrate the results in the continous integration.
+it would cost us too much effort to integrate the results in the continuous integration.
 The report is available at:
 `benchmarks/benchmark_2.0.7.rst <https://github.com/Parquery/icontract/tree/master/benchmarks/benchmark_2.0.7.rst>`_.
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -57,8 +57,8 @@ contract condition as well as variable values at the time of the breach. This pr
 (`DRY <https://en.wikipedia.org/wiki/Don%27t_repeat_yourself>`_) and spare the programmer the tedious task of repeating
 the message that was already written in code.
 
-Second, icontract allows inheritance of the contracts and supports weakining of the preconditions
-as well as strengthening of the postconditions and invariants. Notably, weakining and strengthening of the contracts
+Second, icontract allows inheritance of the contracts and supports weakening of the preconditions
+as well as strengthening of the postconditions and invariants. Notably, weakening and strengthening of the contracts
 is a feature indispensable for modeling many non-trivial class hierarchies. Please see Section :ref:`Inheritance`.
 To the best of our knowledge, there is currently no other Python library that supports inheritance of the contracts in a
 correct way.

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -127,7 +127,7 @@ since they are not associated with an instance of the class.
 We exempt ``__getattribute__``, ``__setattr__`` and ``__delattr__`` methods from observing the invariant since
 these functions alter the state of the instance and thus can not be considered "public".
 
-We also excempt ``__repr__`` method to prevent endless loops when generating error messages.
+We also exempt ``__repr__`` method to prevent endless loops when generating error messages.
 
 The icontract invariants are implemented as class decorators.
 
@@ -242,7 +242,7 @@ which are then supplied as ``OLD`` argument to the postcondition function.
 
 :class:`snapshot` takes a capture function which accepts none, one or more arguments of the function.
 You set the name of the property in ``OLD`` as ``name`` argument to :class:`snapshot`. If there is a single
-argument passed to the the capture function, the name of the ``OLD`` property can be omitted and equals the name
+argument passed to the capture function, the name of the ``OLD`` property can be omitted and equals the name
 of the argument.
 
 Here is an example that uses snapshots to check that a value was appended to the list:
@@ -498,7 +498,7 @@ The example below illustrates how snapshots are inherited:
 
 Toggling Contracts
 ------------------
-By default, the contract checks (including the snapshots) are always perfromed at run-time. To disable them, run the
+By default, the contract checks (including the snapshots) are always performed at run-time. To disable them, run the
 interpreter in optimized mode (``-O`` or ``-OO``, see
 `Python command-line options <https://docs.python.org/3/using/cmdline.html#cmdoption-o>`_).
 

--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -754,7 +754,7 @@ def _decorate_new_with_invariants(new_func: CallableT) -> CallableT:
     if _already_decorated_with_invariants(func=new_func):
         return new_func
 
-    # __new__ can not be async in Python, so we don't neet to check whether it is sync or async here
+    # __new__ can not be async in Python, so we don't need to check whether it is sync or async here
     # (as opposed to the function `_decorate_with_invariants`).
     # See this StackOverflow answer: https://stackoverflow.com/a/33134213/1600678.
 

--- a/icontract/_metaclass.py
+++ b/icontract/_metaclass.py
@@ -134,7 +134,7 @@ def _decorate_namespace_function(bases: List[type], namespace: MutableMapping[st
                     base_snapshots.extend(base_contract_checker.__postcondition_snapshots__)
                     base_postconditions.extend(base_contract_checker.__postconditions__)
 
-        # Collapse preconditions and postconditions from the bases with the the function's own ones
+        # Collapse preconditions and postconditions from the bases with the function's own ones
         preconditions = _collapse_preconditions(
             base_preconditions=base_preconditions,
             bases_have_func=bases_have_func,

--- a/icontract/_represent.py
+++ b/icontract/_represent.py
@@ -258,7 +258,7 @@ def inspect_decorator(lines: List[str], lineno: int, filename: str) -> Decorator
 
     decorator_lines = lines[decorator_lineno:decorator_end_lineno]
 
-    # We need to dedent the decorator and add a dummy decoratee so that we can parse its text as valid source code.
+    # We need to dedent the decorator and add a dummy decorate so that we can parse its text as valid source code.
     decorator_text = textwrap.dedent("".join(decorator_lines)) + "def dummy_{}(): pass".format(uuid.uuid4().hex)
 
     atok = asttokens.ASTTokens(decorator_text, parse=True)


### PR DESCRIPTION
We fixed typos in various places in the documentation and docstrings.