### PR TITLE
Updated benchmarks and tests to use deal 4.23.3

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -30,9 +30,9 @@ def benchmark_against_others(repo_root: pathlib.Path, overwrite: bool) -> None:
         out.append('\n')
 
         out.append(('The benchmarks were executed on {}.\nWe used Python {}, '
-                    'icontract {}, deal 4.1.0 and dpcontracts 0.6.0.\n\n').format(cpuinfo.get_cpu_info()['brand'],
-                                                                                  platform.python_version(),
-                                                                                  icontract.__version__))
+                    'icontract {}, deal 4.23.3 and dpcontracts 0.6.0.\n\n').format(cpuinfo.get_cpu_info()['brand'],
+                                                                                   platform.python_version(),
+                                                                                   icontract.__version__))
 
         out.append('The following tables summarize the results.\n\n')
         stdouts = []  # type: List[str]

--- a/docs/source/benchmarks.rst
+++ b/docs/source/benchmarks.rst
@@ -19,7 +19,7 @@ The following scripts were run:
 * `benchmarks/against_others/compare_postcondition.py <https://github.com/Parquery/icontract/tree/master/benchmarks/against_others/compare_postcondition.py>`_
 
 The benchmarks were executed on Intel(R) Xeon(R) E-2276M  CPU @ 2.80GHz.
-We used Python 3.8.5, icontract 2.4.1, deal 4.1.0 and dpcontracts 0.6.0.
+We used Python 3.9.9, icontract 2.6.1, deal 4.23.3 and dpcontracts 0.6.0.
 
 The following tables summarize the results.
 
@@ -28,10 +28,10 @@ Benchmarking invariant at __init__:
 =========================  ============  ==============  =======================
 Case                         Total time    Time per run    Relative time per run
 =========================  ============  ==============  =======================
-`ClassWithIcontract`             1.33 s         1.33 μs                     100%
-`ClassWithDpcontracts`           0.45 s         0.45 μs                      34%
-`ClassWithDeal`                  2.62 s         2.62 μs                     197%
-`ClassWithInlineContract`        0.27 s         0.27 μs                      20%
+`ClassWithIcontract`             1.45 s         1.45 μs                     100%
+`ClassWithDpcontracts`           0.48 s         0.48 μs                      33%
+`ClassWithDeal`                  1.73 s         1.73 μs                     119%
+`ClassWithInlineContract`        0.28 s         0.28 μs                      19%
 =========================  ============  ==============  =======================
 
 Benchmarking invariant at a function:
@@ -39,10 +39,10 @@ Benchmarking invariant at a function:
 =========================  ============  ==============  =======================
 Case                         Total time    Time per run    Relative time per run
 =========================  ============  ==============  =======================
-`ClassWithIcontract`             1.98 s         1.98 μs                     100%
-`ClassWithDpcontracts`           0.46 s         0.46 μs                      23%
-`ClassWithDeal`                  7.13 s         7.13 μs                     360%
-`ClassWithInlineContract`        0.23 s         0.23 μs                      12%
+`ClassWithIcontract`             2.04 s         2.04 μs                     100%
+`ClassWithDpcontracts`           0.49 s         0.49 μs                      24%
+`ClassWithDeal`                  4.67 s         4.67 μs                     230%
+`ClassWithInlineContract`        0.23 s         0.23 μs                      11%
 =========================  ============  ==============  =======================
 
 Benchmarking precondition:
@@ -50,9 +50,9 @@ Benchmarking precondition:
 ===============================  ============  ==============  =======================
 Case                               Total time    Time per run    Relative time per run
 ===============================  ============  ==============  =======================
-`function_with_icontract`              0.04 s         3.71 μs                     100%
-`function_with_dpcontracts`            0.51 s        50.52 μs                    1361%
-`function_with_deal`                   0.13 s        12.64 μs                     341%
+`function_with_icontract`              0.04 s         3.91 μs                     100%
+`function_with_dpcontracts`            0.54 s        53.92 μs                    1377%
+`function_with_deal`                   0.04 s         4.16 μs                     106%
 `function_with_inline_contract`        0.00 s         0.15 μs                       4%
 ===============================  ============  ==============  =======================
 
@@ -61,11 +61,11 @@ Benchmarking postcondition:
 ===============================  ============  ==============  =======================
 Case                               Total time    Time per run    Relative time per run
 ===============================  ============  ==============  =======================
-`function_with_icontract`              0.04 s         3.97 μs                     100%
-`function_with_dpcontracts`            0.51 s        50.51 μs                    1274%
-`function_with_deal_post`              0.01 s         0.90 μs                      23%
-`function_with_deal_ensure`            0.01 s         1.23 μs                      31%
-`function_with_inline_contract`        0.00 s         0.15 μs                       4%
+`function_with_icontract`              0.04 s         4.39 μs                     100%
+`function_with_dpcontracts`            0.53 s        52.51 μs                    1197%
+`function_with_deal_post`              0.01 s         1.16 μs                      26%
+`function_with_deal_ensure`            0.01 s         1.04 μs                      24%
+`function_with_inline_contract`        0.00 s         0.15 μs                       3%
 ===============================  ============  ==============  =======================
 
 

--- a/setup.py
+++ b/setup.py
@@ -55,8 +55,8 @@ setup(
             'mypy==0.950', 'pylint==2.13.9', 'yapf==0.20.2', 'tox>=3.0.0', 'pydocstyle>=6.1.1,<7', 'coverage>=4.5.1,<5',
             'docutils>=0.14,<1', 'pygments>=2.2.0,<3', 'dpcontracts==0.6.0', 'tabulate>=0.8.7,<1',
             'py-cpuinfo>=5.0.0,<6', 'typeguard>=2,<3', 'astor==0.8.1', 'numpy>=1,<2'
-        ] + (['deal==4.1.0'] if sys.version_info >= (3, 8) else []) + (['asyncstdlib==3.9.1']
-                                                                       if sys.version_info >= (3, 8) else []),
+        ] + (['deal==4.23.3'] if sys.version_info >= (3, 8) else []) + (['asyncstdlib==3.9.1']
+                                                                        if sys.version_info >= (3, 8) else []),
     },
     py_modules=['icontract'],
     package_data={"icontract": ["py.typed"]},

--- a/tests_with_others/test_deal.py
+++ b/tests_with_others/test_deal.py
@@ -5,7 +5,7 @@ import deal
 
 
 class TestDeal(unittest.TestCase):
-    def test_recursion_unhandled_in_preconditions(self) -> None:
+    def test_recursion_handled_in_preconditions(self) -> None:
         @deal.pre(lambda _: another_func())
         @deal.pre(lambda _: yet_another_func())
         def some_func() -> bool:
@@ -28,8 +28,7 @@ class TestDeal(unittest.TestCase):
         except Exception as err:
             cause_err = err.__cause__
 
-        self.assertIsNotNone(cause_err)
-        self.assertIsInstance(cause_err, RecursionError)
+        self.assertIsNone(cause_err, "Deal can deal with the recursive contracts.")
 
     def test_inheritance_of_postconditions_incorrect(self) -> None:
         class A:


### PR DESCRIPTION
We updated the benchmarks and tests to compare with the newest deal
version 4.23.3 for up-to-date comparison between the features and
computational efficiency.

Fixes #244.