### PR TITLE
Upgraded to latest sphinx 5

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,4 +1,4 @@
-sphinx>=3.4.3,<4
+sphinx>=5,<6
 sphinx-autodoc-typehints>=1.11.1
-sphinx-rtd-theme>=0.5.1,<1
+sphinx-rtd-theme>=1,<2
 autodocsumm>=0.2.2,<1


### PR DESCRIPTION
We had to upgrade the sphinx since its dependency jinja2 caused problems
due to deprecations.