### PR TITLE
Added wheels to releases

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -32,5 +32,5 @@ jobs:
         TWINE_USERNAME: "__token__"
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
       run: |
-        python setup.py sdist
+        python setup.py sdist bdist_wheel
         twine upload dist/*

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ dist/
 .coverage
 htmlcov
 README.html
+build/


### PR DESCRIPTION
We added wheels to the releases since some systems are not allowed to
install source distributions.

Directly related to #250.