### PR TITLE
Fixed mypy error on missing ``asttokens.ASTTokens``

### DIFF
--- a/icontract/_represent.py
+++ b/icontract/_represent.py
@@ -8,7 +8,7 @@ import textwrap
 import uuid
 from typing import (Any, Mapping, MutableMapping, Callable, List, Dict, cast, Optional)  # pylint: disable=unused-import
 
-import asttokens
+import asttokens.asttokens
 
 import icontract._recompute
 from icontract._types import Contract
@@ -38,7 +38,7 @@ class Visitor(ast.NodeVisitor):
     # pylint: disable=missing-docstring
 
     def __init__(self, recomputed_values: Mapping[ast.AST, Any], variable_lookup: List[Mapping[str, Any]],
-                 atok: asttokens.ASTTokens) -> None:
+                 atok: asttokens.asttokens.ASTTokens) -> None:
         """
         Initialize.
 
@@ -185,7 +185,7 @@ def is_lambda(a_function: CallableT) -> bool:
 class ConditionLambdaInspection:
     """Represent the inspection of the condition function given as a lambda."""
 
-    def __init__(self, atok: asttokens.ASTTokens, node: ast.Lambda) -> None:
+    def __init__(self, atok: asttokens.asttokens.ASTTokens, node: ast.Lambda) -> None:
         """
         Initialize.
 
@@ -207,7 +207,7 @@ _DEF_CLASS_RE = re.compile(r'^\s*(async\s+def|def |class )')
 class DecoratorInspection:
     """Represent the inspection of a decorator extracted from a source file and embedded in a dummy dynamic module."""
 
-    def __init__(self, atok: asttokens.ASTTokens, node: ast.Call) -> None:
+    def __init__(self, atok: asttokens.asttokens.ASTTokens, node: ast.Call) -> None:
         """
         Initialize.
 
@@ -261,7 +261,7 @@ def inspect_decorator(lines: List[str], lineno: int, filename: str) -> Decorator
     # We need to dedent the decorator and add a dummy decorate so that we can parse its text as valid source code.
     decorator_text = textwrap.dedent("".join(decorator_lines)) + "def dummy_{}(): pass".format(uuid.uuid4().hex)
 
-    atok = asttokens.ASTTokens(decorator_text, parse=True)
+    atok = asttokens.asttokens.ASTTokens(decorator_text, parse=True)
 
     if not isinstance(atok.tree, ast.Module):
         raise ValueError(("Expected the parsed decorator text to live in an AST module. "

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         'dev': [
-            'mypy==0.950', 'pylint==2.13.9', 'yapf==0.20.2', 'tox>=3.0.0', 'pydocstyle>=6.1.1,<7', 'coverage>=4.5.1,<5',
+            'mypy==0.971', 'pylint==2.13.9', 'yapf==0.20.2', 'tox>=3.0.0', 'pydocstyle>=6.1.1,<7', 'coverage>=4.5.1,<5',
             'docutils>=0.14,<1', 'pygments>=2.2.0,<3', 'dpcontracts==0.6.0', 'tabulate>=0.8.7,<1',
             'py-cpuinfo>=5.0.0,<6', 'typeguard>=2,<3', 'astor==0.8.1', 'numpy>=1,<2'
         ] + (['deal==4.23.3'] if sys.version_info >= (3, 8) else []) + (['asyncstdlib==3.9.1']


### PR DESCRIPTION
Mypy complained that ``asttokens.ASTTokens`` is missing with the newest
asttokens version (2.0.7). Honestly, we are at loss what caused this
error as ``asttokens/__init__.py`` did not change. We tried updating
mypy to the latest version (0.971) which did not fix the error either.

We are leaving mypy set to the latest version and fix the mypy error by
explicitly writing ``asttokens.asttokens.ASTTokens`` instead of
``asttokens.ASTTokens``. While it is ugly, it is a quick fix for now.