### PR TITLE
Included `tests_3_6` and `tests_3_7` in precommit

### DIFF
--- a/precommit.py
+++ b/precommit.py
@@ -25,6 +25,12 @@ def main() -> int:
     print("YAPF'ing...")
     yapf_targets = ["tests", "icontract", "setup.py", "precommit.py", "benchmark.py", "benchmarks", "tests_with_others"]
 
+    if sys.version_info >= (3, 6):
+        yapf_targets.append('tests_3_6')
+
+    if sys.version_info >= (3, 7):
+        yapf_targets.append('tests_3_7')
+
     if sys.version_info >= (3, 8, 5):
         yapf_targets.append('tests_3_8')
 
@@ -37,16 +43,31 @@ def main() -> int:
 
     print("Mypy'ing...")
     mypy_targets = ["icontract", "tests"]
+    if sys.version_info >= (3, 6):
+        mypy_targets.append('tests_3_6')
+
+    if sys.version_info >= (3, 7):
+        mypy_targets.append('tests_3_7')
+
     if sys.version_info >= (3, 8):
         mypy_targets.append('tests_3_8')
+        mypy_targets.append('tests_with_others')
 
     subprocess.check_call(["mypy", "--strict"] + mypy_targets, cwd=str(repo_root))
 
     print("Pylint'ing...")
     pylint_targets = ['icontract', 'tests']
 
+    if sys.version_info >= (3, 6):
+        pylint_targets.append('tests_3_6')
+
+    if sys.version_info >= (3, 7):
+        pylint_targets.append('tests_3_7')
+
     if sys.version_info >= (3, 8):
         pylint_targets.append('tests_3_8')
+        pylint_targets.append('tests_with_others')
+
     subprocess.check_call(["pylint", "--rcfile=pylint.rc"] + pylint_targets, cwd=str(repo_root))
 
     print("Pydocstyle'ing...")

--- a/tests_3_6/__init__.py
+++ b/tests_3_6/__init__.py
@@ -7,6 +7,7 @@ For example, one such feature is literal string interpolation.
 import sys
 
 if sys.version_info < (3, 6):
+
     def load_tests(loader, suite, pattern):  # pylint: disable=unused-argument
         """Ignore all the tests for lower Python versions."""
         return suite

--- a/tests_3_6/test_represent.py
+++ b/tests_3_6/test_represent.py
@@ -4,7 +4,6 @@
 
 import textwrap
 import unittest
-import math
 from typing import Optional  # pylint: disable=unused-import
 
 import icontract._represent
@@ -14,7 +13,8 @@ import tests.mock
 
 class TestLiteralStringInterpolation(unittest.TestCase):
     def test_plain_string(self) -> None:
-        @icontract.require(lambda x: f"something" == '')
+        # pylint: disable=f-string-without-interpolation
+        @icontract.require(lambda x: f"something" == '')  # type: ignore
         def func(x: float) -> float:
             return x
 
@@ -26,12 +26,10 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 f"something" == '':
                 f"something" was 'something'
-                x was 0"""),
-            tests.error.wo_mandatory_location(str(violation_err)))
+                x was 0"""), tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_simple_interpolation(self) -> None:
         @icontract.require(lambda x: f"{x}" == '')
@@ -46,12 +44,10 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 f"{x}" == '':
                 f"{x}" was '0'
-                x was 0"""),
-            tests.error.wo_mandatory_location(str(violation_err)))
+                x was 0"""), tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_string_formatting(self) -> None:
         @icontract.require(lambda x: f"{x!s}" == '')
@@ -66,12 +62,10 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 f"{x!s}" == '':
                 f"{x!s}" was '1.984'
-                x was 1.984"""),
-            tests.error.wo_mandatory_location(str(violation_err)))
+                x was 1.984"""), tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_repr_formatting(self) -> None:
         @icontract.require(lambda x: f"{x!r}" == '')
@@ -86,12 +80,10 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 f"{x!r}" == '':
                 f"{x!r}" was '1.984'
-                x was 1.984"""),
-            tests.error.wo_mandatory_location(str(violation_err)))
+                x was 1.984"""), tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_ascii_formatting(self) -> None:
         @icontract.require(lambda x: f"{x!a}" == '')
@@ -106,12 +98,10 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 f"{x!a}" == '':
                 f"{x!a}" was '1.984'
-                x was 1.984"""),
-            tests.error.wo_mandatory_location(str(violation_err)))
+                x was 1.984"""), tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_format_spec(self) -> None:
         @icontract.require(lambda x: f"{x:.3}" == '')
@@ -126,12 +116,10 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 f"{x:.3}" == '':
                 f"{x:.3}" was '1.98'
-                x was 1.984"""),
-            tests.error.wo_mandatory_location(str(violation_err)))
+                x was 1.984"""), tests.error.wo_mandatory_location(str(violation_err)))
 
     def test_conversion_and_format_spec(self) -> None:
         @icontract.require(lambda x: f"{x!r:.3}" == '')
@@ -146,12 +134,10 @@ class TestLiteralStringInterpolation(unittest.TestCase):
 
         self.assertIsNotNone(violation_err)
         self.assertEqual(
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
                 f"{x!r:.3}" == '':
                 f"{x!r:.3}" was '1.9'
-                x was 1.984"""),
-            tests.error.wo_mandatory_location(str(violation_err)))
+                x was 1.984"""), tests.error.wo_mandatory_location(str(violation_err)))
 
 
 if __name__ == '__main__':

--- a/tests_with_others/test_deal.py
+++ b/tests_with_others/test_deal.py
@@ -1,3 +1,7 @@
+# pylint: disable=missing-docstring
+# pylint: disable=broad-except
+# pylint: disable=invalid-name
+
 import unittest
 from typing import Optional
 
@@ -6,7 +10,7 @@ import deal
 
 class TestDeal(unittest.TestCase):
     def test_recursion_handled_in_preconditions(self) -> None:
-        @deal.pre(lambda _: another_func())
+        @deal.pre(lambda _: another_func())  # type: ignore
         @deal.pre(lambda _: yet_another_func())
         def some_func() -> bool:
             return True

--- a/tests_with_others/test_dpcontracts.py
+++ b/tests_with_others/test_dpcontracts.py
@@ -1,3 +1,6 @@
+# pylint: disable=missing-docstring
+# pylint: disable=broad-except
+# pylint: disable=invalid-name
 import unittest
 from typing import Optional
 
@@ -6,13 +9,13 @@ import dpcontracts
 
 class TestDpcontracts(unittest.TestCase):
     def test_recursion_unhandled_in_preconditions(self) -> None:
-        @dpcontracts.require("must another_func", lambda args: another_func())
-        @dpcontracts.require("must yet_another_func", lambda args: yet_another_func())
+        @dpcontracts.require("must another_func", lambda args: another_func())  # type: ignore
+        @dpcontracts.require("must yet_another_func", lambda args: yet_another_func())  # type: ignore
         def some_func() -> bool:
             return True
 
-        @dpcontracts.require("must some_func", lambda args: some_func())
-        @dpcontracts.require("must yet_yet_another_func", lambda args: yet_yet_another_func())
+        @dpcontracts.require("must some_func", lambda args: some_func())  # type: ignore
+        @dpcontracts.require("must yet_yet_another_func", lambda args: yet_yet_another_func())  # type: ignore
         def another_func() -> bool:
             return True
 
@@ -33,12 +36,12 @@ class TestDpcontracts(unittest.TestCase):
 
     def test_inheritance_of_postconditions_incorrect(self) -> None:
         class A:
-            @dpcontracts.ensure('dummy contract', lambda args, result: result % 2 == 0)
+            @dpcontracts.ensure('dummy contract', lambda args, result: result % 2 == 0)  # type: ignore
             def some_func(self) -> int:
                 return 2
 
         class B(A):
-            @dpcontracts.ensure('dummy contract', lambda args, result: result % 3 == 0)
+            @dpcontracts.ensure('dummy contract', lambda args, result: result % 3 == 0)  # type: ignore
             def some_func(self) -> int:
                 # The result 9 satisfies the postcondition of B.some_func, but not A.some_func.
                 return 9


### PR DESCRIPTION
We forgot to include the above-mentioned directories in the pre-commit script. In this patch, we fix the formatting and make sure all the pre-commit checks pass for these directories as well.