### PR TITLE
Upgraded to pylint 2.17.5

### DIFF
--- a/icontract/_recompute.py
+++ b/icontract/_recompute.py
@@ -1096,7 +1096,7 @@ class Visitor(ast.NodeVisitor):
             "Please make a feature request on https://github.com/Parquery/icontract"
         )
 
-    def visit_Return(self, node: ast.Return) -> Any:  # pylint: disable=no-self-use
+    def visit_Return(self, node: ast.Return) -> Any:
         """Raise an exception that this node is unexpected."""
         raise AssertionError(
             "Unexpected return node during the re-computation: {}".format(

--- a/pylint.rc
+++ b/pylint.rc
@@ -7,5 +7,5 @@ generated-members=bottle\.request\.forms\.decode,bottle\.request\.query\.decode
 max-line-length=120
 
 [MESSAGES CONTROL]
-disable=too-few-public-methods,abstract-class-little-used,len-as-condition,bad-continuation,bad-whitespace,duplicate-code,no-else-raise,too-many-locals,too-many-branches,too-many-lines,too-many-arguments,too-many-statements,too-many-nested-blocks,too-many-function-args,too-many-instance-attributes,too-many-public-methods,protected-access,consider-using-in,no-member,consider-using-f-string,use-dict-literal,redundant-keyword-arg,no-self-use
+disable=too-few-public-methods,len-as-condition,duplicate-code,no-else-raise,too-many-locals,too-many-branches,too-many-lines,too-many-arguments,too-many-statements,too-many-nested-blocks,too-many-function-args,too-many-instance-attributes,too-many-public-methods,protected-access,consider-using-in,no-member,consider-using-f-string,use-dict-literal,redundant-keyword-arg
 

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     install_requires=install_requires,
     extras_require={
         "dev": [
-            "pylint==2.13.9",
+            "pylint==2.17.5",
             "tox>=3.0.0",
             "pydocstyle>=6.1.1,<7",
             "coverage>=4.5.1,<5",

--- a/tests/test_args_and_kwargs_in_contract.py
+++ b/tests/test_args_and_kwargs_in_contract.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-docstring
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 # pylint: disable=unnecessary-lambda

--- a/tests/test_error.py
+++ b/tests/test_error.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-self-use
 # pylint: disable=unused-variable
 
 import unittest

--- a/tests/test_for_integrators.py
+++ b/tests/test_for_integrators.py
@@ -1,6 +1,6 @@
 """Test logic that can be potentially used by the integrators such as third-party libraries."""
 
-# pylint: disable=no-self-use,missing-docstring
+# pylint: disable=missing-docstring
 # pylint: disable=invalid-name,unnecessary-lambda
 
 import ast

--- a/tests/test_inheritance_invariant.py
+++ b/tests/test_inheritance_invariant.py
@@ -27,7 +27,7 @@ class TestOK(unittest.TestCase):
             def __repr__(self) -> str:
                 return "instance of A"
 
-            def some_func(self) -> int:  # pylint: disable=no-self-use
+            def some_func(self) -> int:
                 return 1
 
         class B(A):

--- a/tests/test_inheritance_postcondition.py
+++ b/tests/test_inheritance_postcondition.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
-# pylint: disable=no-self-use
 
 import abc
 import sys

--- a/tests/test_inheritance_precondition.py
+++ b/tests/test_inheritance_precondition.py
@@ -1,6 +1,5 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
-# pylint: disable=no-self-use
 
 import abc
 import sys

--- a/tests/test_invariant.py
+++ b/tests/test_invariant.py
@@ -197,7 +197,7 @@ class TestOK(unittest.TestCase):
         inst.some_method()
         self.assertEqual(10, inst.x)
 
-    def test_inv_with_empty_arguments(self) -> None:  # pylint: disable=no-self-use
+    def test_inv_with_empty_arguments(self) -> None:
         z = 42
 
         @icontract.invariant(lambda: z == 42)

--- a/tests/test_postcondition.py
+++ b/tests/test_postcondition.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-self-use
 # pylint: disable=unnecessary-lambda
 
 import abc

--- a/tests/test_precondition.py
+++ b/tests/test_precondition.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-self-use
 # pylint: disable=unnecessary-lambda
 
 import functools

--- a/tests/test_recompute.py
+++ b/tests/test_recompute.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-docstring,invalid-name,no-self-use
+# pylint: disable=missing-docstring,invalid-name
 # pylint: disable=unused-argument
 import ast
 import re

--- a/tests/test_recursion.py
+++ b/tests/test_recursion.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-docstring
-# pylint: disable=no-self-use
 # pylint: disable=unnecessary-lambda
 import unittest
 from typing import List

--- a/tests/test_represent.py
+++ b/tests/test_represent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-docstring,invalid-name,no-self-use
+# pylint: disable=missing-docstring,invalid-name
 # pylint: disable=unused-argument
 # pylint: disable=unnecessary-lambda
 

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -2,7 +2,7 @@
 # pylint: disable=invalid-name
 # pylint: disable=unnecessary-lambda
 # pylint: disable=unused-argument
-# pylint: disable=no-self-use
+
 import textwrap
 import unittest
 from typing import List, Optional  # pylint: disable=unused-import

--- a/tests/test_threading.py
+++ b/tests/test_threading.py
@@ -1,4 +1,4 @@
-# pylint: disable=missing-docstring,unnecessary-lambda,no-self-use
+# pylint: disable=missing-docstring,unnecessary-lambda
 import threading
 import unittest
 

--- a/tests/test_typeguard.py
+++ b/tests/test_typeguard.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-docstring
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 

--- a/tests_3_6/test_represent.py
+++ b/tests_3_6/test_represent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-docstring,invalid-name,no-self-use
+# pylint: disable=missing-docstring,invalid-name
 # pylint: disable=unused-argument
 
 import textwrap

--- a/tests_3_8/async/separately_test_concurrent.py
+++ b/tests_3_8/async/separately_test_concurrent.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-docstring
-# pylint: disable=no-self-use
 # pylint: disable=unnecessary-lambda
 # pylint: disable=disallowed-name
 import asyncio

--- a/tests_3_8/async/test_args_and_kwargs_in_contract.py
+++ b/tests_3_8/async/test_args_and_kwargs_in_contract.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-docstring
-# pylint: disable=no-self-use
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
 # pylint: disable=unnecessary-lambda

--- a/tests_3_8/async/test_recursion.py
+++ b/tests_3_8/async/test_recursion.py
@@ -1,5 +1,4 @@
 # pylint: disable=missing-docstring
-# pylint: disable=no-self-use
 # pylint: disable=unnecessary-lambda
 import unittest
 from typing import List

--- a/tests_3_8/test_error.py
+++ b/tests_3_8/test_error.py
@@ -1,7 +1,6 @@
 # pylint: disable=missing-docstring
 # pylint: disable=invalid-name
 # pylint: disable=unused-argument
-# pylint: disable=no-self-use
 # pylint: disable=unused-variable
 
 import textwrap

--- a/tests_3_8/test_represent.py
+++ b/tests_3_8/test_represent.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-# pylint: disable=missing-docstring,invalid-name,no-self-use
+# pylint: disable=missing-docstring,invalid-name
 # pylint: disable=unused-argument
 import textwrap
 import unittest


### PR DESCRIPTION
We upgraded pylint to the latest version to keep up with its development. Eventually, we want to support Python 3.11, so this upgrade is timely as well.