### PR TITLE
Excluded black from dev for Python 3.7

### DIFF
--- a/precommit.py
+++ b/precommit.py
@@ -23,34 +23,42 @@ def main() -> int:
 
     repo_root = pathlib.Path(__file__).parent
 
-    print("Reformatting...")
-    reformat_targets = [
-        "tests",
-        "icontract",
-        "setup.py",
-        "precommit.py",
-        "benchmark.py",
-        "benchmarks",
-        "tests_with_others",
-    ]
-
-    if sys.version_info >= (3, 6):
-        reformat_targets.append("tests_3_6")
-
-    if sys.version_info >= (3, 7):
-        reformat_targets.append("tests_3_7")
-
-    if sys.version_info >= (3, 8, 5):
-        reformat_targets.append("tests_3_8")
-
-    if overwrite:
-        subprocess.check_call(
-            [sys.executable, "-m", "black"] + reformat_targets, cwd=str(repo_root)
+    if sys.version_info < (3, 8):
+        print(
+            "Our formatter, black, supports only Python versions from 3.8 on. "
+            "However, you are running Python {}. Hence, the reformatting step "
+            "will be skipped.".format(sys.version_info)
         )
     else:
-        subprocess.check_call(
-            [sys.executable, "-m", "black"] + reformat_targets, cwd=str(repo_root)
-        )
+        print("Reformatting...")
+
+        reformat_targets = [
+            "tests",
+            "icontract",
+            "setup.py",
+            "precommit.py",
+            "benchmark.py",
+            "benchmarks",
+            "tests_with_others",
+        ]
+
+        if sys.version_info >= (3, 6):
+            reformat_targets.append("tests_3_6")
+
+        if sys.version_info >= (3, 7):
+            reformat_targets.append("tests_3_7")
+
+        if sys.version_info >= (3, 8, 5):
+            reformat_targets.append("tests_3_8")
+
+        if overwrite:
+            subprocess.check_call(
+                [sys.executable, "-m", "black"] + reformat_targets, cwd=str(repo_root)
+            )
+        else:
+            subprocess.check_call(
+                [sys.executable, "-m", "black"] + reformat_targets, cwd=str(repo_root)
+            )
 
     if sys.version_info < (3, 8):
         print(

--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,6 @@ setup(
     extras_require={
         "dev": [
             "pylint==2.13.9",
-            "black==23.9.1",
             "tox>=3.0.0",
             "pydocstyle>=6.1.1,<7",
             "coverage>=4.5.1,<5",
@@ -66,6 +65,7 @@ setup(
             "numpy>=1,<2",
         ]
         + (["mypy==1.5.1"] if sys.version_info >= (3, 8) else [])
+        + (["black==23.9.1"] if sys.version_info >= (3, 8) else [])
         + (["deal==4.23.3"] if sys.version_info >= (3, 8) else [])
         + (["asyncstdlib==3.9.1"] if sys.version_info >= (3, 8) else []),
     },


### PR DESCRIPTION
We excluded black from development dependencies for Python 3.7 as black dropped support for Python 3.7 (due to its EOL) and only supports Python versions from 3.8 on.