### PR TITLE
Removed meta data files from setup.py

### DIFF
--- a/requirements-doc.txt
+++ b/requirements-doc.txt
@@ -1,3 +1,5 @@
+asttokens>=2,<3
+typing_extensions
 sphinx>=5,<6
 sphinx-autodoc-typehints>=1.11.1
 sphinx-rtd-theme>=1,<2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,0 @@
-asttokens>=2,<3
-typing_extensions

--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,6 @@ here = os.path.abspath(os.path.dirname(__file__))  # pylint: disable=invalid-nam
 with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
     long_description = fid.read()  # pylint: disable=invalid-name
 
-with open(os.path.join(here, "requirements.txt"), encoding="utf-8") as fid:
-    install_requires = [line for line in fid.read().splitlines() if line.strip()]
-
 # Please keep the meta information in sync with icontract/__init__.py.
 #
 # (mristin, 2020-10-09) We had to denormalize icontract_meta module (which
@@ -48,7 +45,10 @@ setup(
     license="License :: OSI Approved :: MIT License",
     keywords="design-by-contract precondition postcondition validation",
     packages=find_packages(exclude=["tests*"]),
-    install_requires=install_requires,
+    install_requires=[
+        "asttokens>=2,<3",
+        "typing_extensions",
+    ],
     extras_require={
         "dev": [
             "pylint==2.17.5",
@@ -71,5 +71,4 @@ setup(
     },
     py_modules=["icontract"],
     package_data={"icontract": ["py.typed"]},
-    data_files=[(".", ["LICENSE.txt", "README.rst", "requirements.txt"])],
 )


### PR DESCRIPTION
We removed the license, readme and requirements.txt from setup.py as they are not really necessary, and only clutter the distribution.

Fixes #254.