### PR TITLE
Released 2.6.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+2.6.3
+=====
+* Removed meta data files from setup.py (#262)
+* Added support for python 3.11 (#260)
+* Fixed in-progress set for async (#256)
+
 2.6.2
 =====
 * Added wheels to releases (#251)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = "2.6.2"
+__version__ = "2.6.3"
 __author__ = "Marko Ristin"
 __copyright__ = "Copyright 2019 Parquery AG"
 __license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="icontract",
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version="2.6.2",
+    version="2.6.3",
     description="Provide design-by-contract with informative violation messages.",
     long_description=long_description,
     url="https://github.com/Parquery/icontract",


### PR DESCRIPTION
* Removed meta data files from setup.py (#262)
* Added support for python 3.11 (#260)
* Fixed in-progress set for async (#256)