### PR TITLE
Restored Python 3.6 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
@@ -47,6 +48,7 @@ setup(
     packages=find_packages(exclude=["tests*"]),
     install_requires=[
         "asttokens>=2,<3",
+        'contextvars;python_version=="3.6"',
         "typing_extensions",
     ],
     extras_require={


### PR DESCRIPTION
The support for Python 3.6 has been dropped in #257 as GitHub removed its support in the CI pipeline. With this patch, we restored the support of Python 3.6. Notably, we had to add the package `contextvars` conditioned on Python 3.6.