### PR TITLE
Replaced YAPF comments with black comments

### DIFF
--- a/benchmarks/against_others/compare_invariant.py
+++ b/benchmarks/against_others/compare_invariant.py
@@ -93,22 +93,22 @@ def measure_invariant_at_init() -> None:
     table = []  # type: List[List[str]]
 
     for cls, duration in zip(clses, durations):
-        # yapf: disable
+        # fmt: off
         table.append([
             '`{}`'.format(cls),
             '{:.2f} s'.format(duration),
             '{:.2f} μs'.format(duration * 1000 * 1000 / number),
             '{:.0f}%'.format(duration * 100 / durations[0])
         ])
-        # yapf: enable
+        # fmt: on
 
-    # yapf: disable
+    # fmt: off
     table_str = tabulate.tabulate(
         table,
         headers=['Case', 'Total time', 'Time per run', 'Relative time per run'],
         colalign=('left', 'right', 'right', 'right'),
         tablefmt='rst')
-    # yapf: enable
+    # fmt: on
 
     writeln_utf8(table_str)
 
@@ -130,22 +130,22 @@ def measure_invariant_at_function() -> None:
     table = []  # type: List[List[str]]
 
     for cls, duration in zip(clses, durations):
-        # yapf: disable
+        # fmt: off
         table.append([
             '`{}`'.format(cls),
             '{:.2f} s'.format(duration),
             '{:.2f} μs'.format(duration * 1000 * 1000 / number),
             '{:.0f}%'.format(duration * 100 / durations[0])
         ])
-        # yapf: enable
+        # fmt: on
 
-    # yapf: disable
+    # fmt: off
     table_str = tabulate.tabulate(
         table,
         headers=['Case', 'Total time', 'Time per run', 'Relative time per run'],
         colalign=('left', 'right', 'right', 'right'),
         tablefmt='rst')
-    # yapf: enable
+    # fmt: on
 
     writeln_utf8(table_str)
 

--- a/benchmarks/against_others/compare_postcondition.py
+++ b/benchmarks/against_others/compare_postcondition.py
@@ -77,22 +77,22 @@ def measure_functions() -> None:
     table = []  # type: List[List[str]]
 
     for func, duration in zip(funcs, durations):
-        # yapf: disable
+        # fmt: off
         table.append([
             '`{}`'.format(func),
             '{:.2f} s'.format(duration),
             '{:.2f} μs'.format(duration * 1000 * 1000 / number),
             '{:.0f}%'.format(duration * 100 / durations[0])
         ])
-        # yapf: enable
+        # fmt: on
 
-    # yapf: disable
+    # fmt: off
     table_str = tabulate.tabulate(
         table,
         headers=['Case', 'Total time', 'Time per run', 'Relative time per run'],
         colalign=('left', 'right', 'right', 'right'),
         tablefmt='rst')
-    # yapf: enable
+    # fmt: on
 
     writeln_utf8(table_str)
 

--- a/benchmarks/against_others/compare_precondition.py
+++ b/benchmarks/against_others/compare_precondition.py
@@ -75,22 +75,22 @@ def measure_functions() -> None:
     table = []  # type: List[List[str]]
 
     for func, duration in zip(funcs, durations):
-        # yapf: disable
+        # fmt: off
         table.append([
             '`{}`'.format(func),
             '{:.2f} s'.format(duration),
             '{:.2f} μs'.format(duration * 1000 * 1000 / number),
             '{:.0f}%'.format(duration * 100 / durations[0])
         ])
-        # yapf: enable
+        # fmt: on
 
-    # yapf: disable
+    # fmt: off
     table_str = tabulate.tabulate(
         table,
         headers=['Case', 'Total time', 'Time per run', 'Relative time per run'],
         colalign=('left', 'right', 'right', 'right'),
         tablefmt='rst')
-    # yapf: enable
+    # fmt: on
 
     writeln_utf8(table_str)
 

--- a/icontract/_recompute.py
+++ b/icontract/_recompute.py
@@ -658,13 +658,13 @@ class Visitor(ast.NodeVisitor):
             )
 
         # Short-circuit tracing the all quantifier over a generator expression
-        # yapf: disable
+        # fmt: off
         if (
                 func == builtins.all  # pylint: disable=comparison-with-callable
                 and len(node.args) == 1
                 and isinstance(node.args[0], ast.GeneratorExp)
         ):
-            # yapf: enable
+            # fmt: on
             result = self._trace_all_with_generator(func=func, node=node)
 
             if result is PLACEHOLDER:

--- a/icontract/_represent.py
+++ b/icontract/_represent.py
@@ -428,7 +428,7 @@ def inspect_lambda_condition(
     return lambda_inspection
 
 
-# yapf: disable
+# fmt: off
 def collect_variable_lookup(
         condition: Callable[..., Any],
         resolved_kwargs: Optional[Mapping[str, Any]] = None
@@ -443,7 +443,7 @@ def collect_variable_lookup(
         The keyword arguments are added to the variable look-up tables accordingly.
         If ``resolved_kwargs`` is None, no keyword arguments will be added to the variable look-up table.
     """
-    # yapf: enable
+    # fmt: on
     variable_lookup = []  # type: List[Mapping[str, Any]]
 
     ##

--- a/precommit.py
+++ b/precommit.py
@@ -110,24 +110,24 @@ def main() -> int:
     env = os.environ.copy()
     env["ICONTRACT_SLOW"] = "true"
 
-    # yapf: disable
+    # fmt: off
     subprocess.check_call(
         ["coverage", "run",
          "--source", "icontract",
          "-m", "unittest", "discover"],
         cwd=str(repo_root),
         env=env)
-    # yapf: enable
+    # fmt: on
 
     if sys.version_info >= (3, 8):
-        # yapf: disable
+        # fmt: off
         subprocess.check_call(
             ["coverage", "run",
              "--source", "icontract",
              "-a", "-m", "tests_3_8.async.separately_test_concurrent"],
             cwd=str(repo_root),
             env=env)
-        # yapf: enable
+        # fmt: on
 
     subprocess.check_call(["coverage", "report"])
 

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     author="Marko Ristin",
     author_email="marko@ristin.ch",
     classifiers=[
-        # yapf: disable
+        # fmt: off
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
@@ -41,7 +41,7 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10'
-        # yapf: enable
+        # fmt: on
     ],
     license="License :: OSI Approved :: MIT License",
     keywords="design-by-contract precondition postcondition validation",

--- a/tests/test_represent.py
+++ b/tests/test_represent.py
@@ -552,11 +552,11 @@ class TestGeneratorExpr(unittest.TestCase):
     def test_multiple_for(self) -> None:
         lst = [[1, 2], [3]]
 
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda x: all(item == x for sublst in lst for item in sublst)
         )
-        # yapf: enable
+        # fmt: on
         def func(x: int) -> int:
             return x
 
@@ -672,7 +672,7 @@ class TestListComprehension(unittest.TestCase):
     def test_nested(self) -> None:
         lst_of_lsts = [[1, 2, 3]]
 
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda:
             [
@@ -680,7 +680,7 @@ class TestListComprehension(unittest.TestCase):
                 for sublst in lst_of_lsts
             ] == [[]]
         )
-        # yapf: enable
+        # fmt: on
         def func() -> None:
             pass
 
@@ -740,7 +740,7 @@ class TestSetComprehension(unittest.TestCase):
     def test_nested(self) -> None:
         lst_of_lsts = [[1, 2, 3]]
 
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda:
             {
@@ -748,7 +748,7 @@ class TestSetComprehension(unittest.TestCase):
                 for lst in lst_of_lsts
             } == set()
         )
-        # yapf: enable
+        # fmt: on
         def func() -> None:
             pass
 
@@ -805,7 +805,7 @@ class TestDictComprehension(unittest.TestCase):
     def test_nested(self) -> None:
         lst_of_lsts = [[1, 2, 3]]
 
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda:
             len({
@@ -813,7 +813,7 @@ class TestDictComprehension(unittest.TestCase):
                 for lst in lst_of_lsts
             }) == 0
         )
-        # yapf: enable
+        # fmt: on
         def func() -> None:
             pass
 
@@ -849,12 +849,12 @@ class TestConditionAsText(unittest.TestCase):
     """Test decompilation of the condition."""
 
     def test_single_line(self) -> None:
-        # yapf: disable
+        # fmt: off
         @icontract.require(lambda x: x > 3)
         def func(x: int) -> int:
             return x
 
-        # yapf: enable
+        # fmt: on
 
         violation_err = None  # type: Optional[icontract.ViolationError]
         try:
@@ -868,13 +868,13 @@ class TestConditionAsText(unittest.TestCase):
         )
 
     def test_condition_on_next_line(self) -> None:
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda x: x > 3)
         def func(x: int) -> int:
             return x
 
-        # yapf: enable
+        # fmt: on
 
         violation_err = None  # type: Optional[icontract.ViolationError]
         try:
@@ -888,7 +888,7 @@ class TestConditionAsText(unittest.TestCase):
         )
 
     def test_condition_on_multiple_lines(self) -> None:
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda x:
             x
@@ -897,7 +897,7 @@ class TestConditionAsText(unittest.TestCase):
         def func(x: int) -> int:
             return x
 
-        # yapf: enable
+        # fmt: on
 
         violation_err = None  # type: Optional[icontract.ViolationError]
         try:
@@ -918,7 +918,7 @@ class TestConditionAsText(unittest.TestCase):
 
     def test_with_multiple_lambdas_on_a_line(self) -> None:
         # pylint: disable=unnecessary-lambda
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             error=lambda x: ValueError("x > 0, but got: {}".format(x)), condition=lambda x: x > 0)
         @icontract.require(
@@ -926,7 +926,7 @@ class TestConditionAsText(unittest.TestCase):
         def func(x: int) -> int:
             return x
 
-        # yapf: enable
+        # fmt: on
 
         value_error = None  # type: Optional[ValueError]
         try:
@@ -1341,7 +1341,7 @@ class TestRecomputationFailure(unittest.TestCase):
 
 class TestTracingAll(unittest.TestCase):
     def test_global_variable(self) -> None:
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda lst:
             all(
@@ -1349,7 +1349,7 @@ class TestTracingAll(unittest.TestCase):
                 for value in lst
             )
         )
-        # yapf: enable
+        # fmt: on
         def func(lst: List[int]) -> None:
             pass
 
@@ -1382,7 +1382,7 @@ class TestTracingAll(unittest.TestCase):
         )
 
     def test_formatted_string(self) -> None:
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda lst:
             all(
@@ -1390,7 +1390,7 @@ class TestTracingAll(unittest.TestCase):
                 for value in lst
             )
         )
-        # yapf: enable
+        # fmt: on
         def func(lst: List[str]) -> None:
             pass
 
@@ -1422,7 +1422,7 @@ class TestTracingAll(unittest.TestCase):
         )
 
     def test_two_fors_and_two_ifs(self) -> None:
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda matrix:
             all(
@@ -1433,7 +1433,7 @@ class TestTracingAll(unittest.TestCase):
                 if i == j
             )
         )
-        # yapf: enable
+        # fmt: on
         def func(matrix: List[List[int]]) -> None:
             pass
 
@@ -1482,7 +1482,7 @@ class TestTracingAll(unittest.TestCase):
     def test_nested_all(self) -> None:
         # Nesting is not recursively followed by design. Only the outer-most all expression should be traced.
 
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda lst_of_lsts:
             all(
@@ -1490,7 +1490,7 @@ class TestTracingAll(unittest.TestCase):
                 for sublst in lst_of_lsts
             )
         )
-        # yapf: enable
+        # fmt: on
         def func(lst_of_lsts: List[List[int]]) -> None:
             pass
 
@@ -1526,7 +1526,7 @@ class TestTracingAll(unittest.TestCase):
             def __repr__(self) -> str:
                 return "Something()"
 
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda something, lst:
             all(
@@ -1534,7 +1534,7 @@ class TestTracingAll(unittest.TestCase):
                 for item in lst
             )
         )
-        # yapf: enable
+        # fmt: on
         def func(something: Something, lst: List[int]) -> None:
             pass
 
@@ -1566,7 +1566,7 @@ class TestTracingAll(unittest.TestCase):
         )
 
     def test_shadows_in_targets(self) -> None:
-        # yapf: disable
+        # fmt: off
         @icontract.require(
             lambda lst_of_lsts:
             all(
@@ -1574,7 +1574,7 @@ class TestTracingAll(unittest.TestCase):
                 for item in lst_of_lsts
             )
         )
-        # yapf: enable
+        # fmt: on
         def func(lst_of_lsts: List[List[int]]) -> None:
             pass
 


### PR DESCRIPTION
We replaced YAPF with black in #265, but forgot to update the comments to turn formatting off on a small number of snippets where the default formatting was unreadable.

In this patch, we replaced the comments to instruct black to skip these snippets.