### PR TITLE
Released 2.6.4

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+2.6.4
+=====
+* Restored Python 3.6 support (#274)
+
+  The support for Python 3.6 has been dropped in #257 as GitHub removed
+  its support in the CI pipeline. With this patch, we restored
+  the support of Python 3.6. Notably, we had to add
+  the package ``contextvars`` conditioned on Python 3.6.
+
 2.6.3
 =====
 * Removed meta data files from setup.py (#262)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = "2.6.3"
+__version__ = "2.6.4"
 __author__ = "Marko Ristin"
 __copyright__ = "Copyright 2019 Parquery AG"
 __license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="icontract",
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version="2.6.3",
+    version="2.6.4",
     description="Provide design-by-contract with informative violation messages.",
     long_description=long_description,
     url="https://github.com/Parquery/icontract",


### PR DESCRIPTION
* Restored Python 3.6 support (#274)

  The support for Python 3.6 has been dropped in #257 as GitHub removed its support in the CI pipeline. With this patch, we restored the support of Python 3.6. Notably, we had to add the package ``contextvars`` conditioned on Python 3.6.