### PR TITLE
Added Python 3.11 to the list of supported Pythons

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
-        'Programming Language :: Python :: 3.10'
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
         # fmt: on
     ],
     license="License :: OSI Approved :: MIT License",


### PR DESCRIPTION
We list Python 3.11 to the list of supported Python versions as it has been already included in the continuous integration, and proved to work.