### PR TITLE
Released 2.6.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,13 @@
+2.6.5
+=====
+* Added Python 3.11 to the list of supported Pythons (#280)
+* Fixed deal dependency marker (#279)
+
+  This patch is important as we silently broke ``setup.py``, which was
+  tolerated by older versions of setuptools, but not any more by
+  the newer ones. With this patch, icontract's ``setup.py`` is made
+  valid again.
+
 2.6.4
 =====
 * Restored Python 3.6 support (#274)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = "2.6.4"
+__version__ = "2.6.5"
 __author__ = "Marko Ristin"
 __copyright__ = "Copyright 2019 Parquery AG"
 __license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="icontract",
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version="2.6.4",
+    version="2.6.5",
     description="Provide design-by-contract with informative violation messages.",
     long_description=long_description,
     url="https://github.com/Parquery/icontract",


### PR DESCRIPTION
* Added Python 3.11 to the list of supported Pythons (#280)
* Fixed deal dependency marker (#279)

  This patch is important as we silently broke ``setup.py``, which was tolerated by older versions of setuptools, but not any more by the newer ones. With this patch, icontract's ``setup.py`` is made valid again.