### PR TITLE
Released 2.6.6

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,12 @@
+2.6.6
+=====
+* Updated typeguard and deal to latest versions (#284)
+
+  This change is needed so that distributions can successfully run
+  the necessary tests with the development dependencies. Previously,
+  the dependencies were outdated, and the old versions were already
+  deprecated in distributions (notably, typegard and deal).
+
 2.6.5
 =====
 * Added Python 3.11 to the list of supported Pythons (#280)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = "2.6.5"
+__version__ = "2.6.6"
 __author__ = "Marko Ristin"
 __copyright__ = "Copyright 2019 Parquery AG"
 __license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="icontract",
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version="2.6.5",
+    version="2.6.6",
     description="Provide design-by-contract with informative violation messages.",
     long_description=long_description,
     url="https://github.com/Parquery/icontract",


### PR DESCRIPTION
* Updated typeguard and deal to latest versions (#284)

  This change is needed so that distributions can successfully run the necessary tests with the development dependencies. Previously, the dependencies were outdated, and the old versions were already deprecated in distributions (notably, typegard and deal).