### PR TITLE
Tested for data classes with fields

### DIFF
--- a/docs/source/known_issues.rst
+++ b/docs/source/known_issues.rst
@@ -1,11 +1,16 @@
 Known Issues
 ============
-**Integration with ``help()``**. We wanted to include the contracts in the output of ``help()``. Unfortunately,
+Integration with ``help()``
+---------------------------
+
+We wanted to include the contracts in the output of ``help()``. Unfortunately,
 ``help()`` renders the ``__doc__`` of the class and not of the instance. For functions, this is the class
 "function" which you can not inherit from. See this
 `discussion on python-ideas <https://groups.google.com/forum/#!topic/python-ideas/c9ntrVuh6WE>`_ for more details.
 
-**Defining contracts outside of decorators**. We need to inspect the source code of the condition and error lambdas to
+Defining contracts outside of decorators
+----------------------------------------
+We need to inspect the source code of the condition and error lambdas to
 generate the violation message and infer the error type in the documentation, respectively. ``inspect.getsource(.)``
 is broken on lambdas defined in decorators in Python 3.5.2+ (see
 `this bug report <https://bugs.python.org/issue21217>`_). We circumvented this bug by using ``inspect.findsource(.)``,
@@ -35,7 +40,9 @@ However, we haven't faced a situation in the code base where we would do somethi
 whether this is a big issue. As long as decorators are directly applied to functions and classes, everything
 worked fine on our code base.
 
-**`*args` and `**kwargs`**. Since handling variable number of positional and/or keyword arguments requires complex
+``*args`` and ``**kwargs``
+--------------------------
+Since handling variable number of positional and/or keyword arguments requires complex
 logic and entails many edge cases (in particular in relation to how the arguments from the actual call are resolved and
 passed to the contract), we did not implement it. These special cases also impose changes that need to propagate to
 rendering the violation messages and related tools such as pyicontract-lint and sphinx-icontract. This is a substantial
@@ -44,3 +51,20 @@ effort and needs to be prioritized accordingly.
 Before we spend a large amount of time on this feature, please give us a signal through
 `the issue 147 <https://github.com/Parquery/icontract/issues/147>`_ and describe your concrete use case and its
 relevance. If there is enough feedback from the users, we will of course consider implementing it.
+
+``dataclasses``
+---------------
+When you define contracts for `dataclasses <https://docs.python.org/3/library/dataclasses.html>`_, make sure you define the contracts *after* decorating the class with ``@dataclass`` decorator:
+
+.. code-block:: python
+
+    >>> import icontract
+    >>> import dataclasses
+
+    >>> @icontract.invariant(lambda self: self.x > 0)
+    ... @dataclasses.dataclass
+    ... class Foo:
+    ...     x: int = dataclasses.field(default=42)
+
+
+This is necessary as we can not re-decorate the methods that ``dataclass`` decorator inserts.


### PR DESCRIPTION
In this patch, we test for `dataclasses` which use `field`'s to define default values. Originally, we thought that there are issues with data classes in general due to the issue #288, but it turned out that the order of decorators matters (``dataclass`` first).

We tested everything, and documented the order of the decorators accordingly.

Fixes #288.