### PR TITLE
Fixed readthedocs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,9 +13,12 @@ sphinx:
 formats:
    - pdf
 
-# Optionally set the version of Python and requirements required to build your docs
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.8"
+
 python:
-   version: 3.8
    install:
    - method: pip
      path: .


### PR DESCRIPTION
The ``build.os`` needs to be set in the readthedocs configuration file, see https://github.com/readthedocs/readthedocs.org/issues/8912.