### PR TITLE
Upgrade coverage to 6.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
             'pylint==2.17.5;python_version>="3.7"',
             "tox>=3.0.0",
             "pydocstyle>=6.3.0,<7",
-            "coverage>=4.5.1,<5",
+            "coverage>=6.5.0,<7",
             "docutils>=0.14,<1",
             "pygments>=2.2.0,<3",
             "dpcontracts==0.6.0",


### PR DESCRIPTION
We received error messages in older version of the coverage so we upgrade to 6.5.0 which seems to work well with coveralls and all the supported Python versions.

See this run for more details:
https://github.com/Parquery/icontract/actions/runs/9779072024/job/26997391256?pr=292