### PR TITLE
Released 2.7.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,16 @@
+2.7.0
+=====
+* Allowed to enforce invariants on attribute setting (#292)
+
+  Originally, we had enforced invariants only at calls to "normal"
+  methods, and excluded ``__setattr__`` since it is usually too expensive
+  to verify invariants whenever setting an attribute.
+
+  However, there are use cases where the users prefer to incur to
+  computational overhead for correctness. To that end, we introduced the
+  feature to steer when the invariants are enforced (at method calls,
+  on setting attributes, or in both situations).
+
 2.6.6
 =====
 * Updated typeguard and deal to latest versions (#284)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = "2.6.6"
+__version__ = "2.7.0"
 __author__ = "Marko Ristin"
 __copyright__ = "Copyright 2019 Parquery AG"
 __license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="icontract",
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version="2.6.6",
+    version="2.7.0",
     description="Provide design-by-contract with informative violation messages.",
     long_description=long_description,
     url="https://github.com/Parquery/icontract",


### PR DESCRIPTION
* Allowed to enforce invariants on attribute setting (#292)

  Originally, we had enforced invariants only at calls to "normal" methods, and excluded ``__setattr__`` since it is usually too expensive to verify invariants whenever setting an attribute.

  However, there are use cases where the users prefer to incur to computational overhead for correctness. To that end, we introduced the feature to steer when the invariants are enforced (at method calls, on setting attributes, or in both situations).