### PR TITLE
Fixed invariants leak between related classes

### DIFF
--- a/icontract/_checkers.py
+++ b/icontract/_checkers.py
@@ -1213,7 +1213,7 @@ def add_invariant_checks(cls: ClassT) -> None:
         # We need to ignore __repr__ to prevent endless loops when generating error messages.
         # We also need to ignore __getattribute__ since pretty much any operation on the instance
         # will result in an endless loop.
-        if name in ["__new__", "__repr__", "__getattribute__"]:
+        if name in ("__new__", "__repr__", "__getattribute__"):
             continue
 
         if name == "__init__":


### PR DESCRIPTION
With pull request #292, we allowed users to specify the events which trigger the invariant checks for each individual invariant.

This introduced a bug where invariants added to a child class were also added to a parent class.

In this patch, we fixed the issue.

Fixes #295.