### PR TITLE
Released 2.7.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+2.7.1
+=====
+* Fixed invariants leak between related classes (#297)
+
+This is a critical bugfix patch version. We introduced a bug in
+2.7.0 (#292) where invariants defined on derived classes leaked up
+to parent classes. This bug is fixed in this version.
+
 2.7.0
 =====
 * Allowed to enforce invariants on attribute setting (#292)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = "2.7.0"
+__version__ = "2.7.1"
 __author__ = "Marko Ristin"
 __copyright__ = "Copyright 2019 Parquery AG"
 __license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="icontract",
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version="2.7.0",
+    version="2.7.1",
     description="Provide design-by-contract with informative violation messages.",
     long_description=long_description,
     url="https://github.com/Parquery/icontract",


### PR DESCRIPTION
* Fixed invariants leak between related classes (#297)

This is a critical bugfix patch version. We introduced a bug in 2.7.0 (#292) where invariants defined on derived classes leaked up to parent classes. This bug is fixed in this version.