### PR TITLE
Release 2.7.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,17 @@
+2.7.2
+=====
+* Fix child invariants checked in ``super().__init__`` (#301)
+* Support Python 3.13 (#309)
+* Add support for Python 3.12 (#308)
+
+This is a critical bugfix patch version. Previously, we determined
+the invariants based on the ``self`` passed to the function. However,
+in case of ``super().__init__``, the invariants that need to be checked
+after the call are those belonging to to the super class, not
+the current (child) class. This lead to erroneous invariant checks, where
+the invariants of the child class where checked after the super-init call
+in the parent class.
+
 2.7.1
 =====
 * Fixed invariants leak between related classes (#297)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = "2.7.1"
+__version__ = "2.7.2"
 __author__ = "Marko Ristin"
 __copyright__ = "Copyright 2019 Parquery AG"
 __license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="icontract",
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version="2.7.1",
+    version="2.7.2",
     description="Provide design-by-contract with informative violation messages.",
     long_description=long_description,
     url="https://github.com/Parquery/icontract",


### PR DESCRIPTION
* Fix child invariants checked in ``super().__init__`` (#301)
* Support Python 3.13 (#309)
* Add support for Python 3.12 (#308)

This is a critical bugfix patch version. Previously, we determined the invariants based on the ``self`` passed to the function. However, in case of ``super().__init__``, the invariants that need to be checked after the call are those belonging to to the super class, not the current (child) class. This lead to erroneous invariant checks, where the invariants of the child class where checked after the super-init call in the parent class.