### PR TITLE
Release 2.7.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+2.7.3
+=====
+* Treat ``__setstate__`` as constructor (#311)
+
+This is a patch release so that we can enable unpickling of class
+instances where some of the attributes are not pickled and only restored
+in ``__setstate__``.
+
 2.7.2
 =====
 * Fix child invariants checked in ``super().__init__`` (#301)

--- a/icontract/__init__.py
+++ b/icontract/__init__.py
@@ -8,7 +8,7 @@
 # imports in setup.py.
 
 # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-__version__ = "2.7.2"
+__version__ = "2.7.3"
 __author__ = "Marko Ristin"
 __copyright__ = "Copyright 2019 Parquery AG"
 __license__ = "MIT"

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(here, "README.rst"), encoding="utf-8") as fid:
 setup(
     name="icontract",
     # Don't forget to update the version in __init__.py and CHANGELOG.rst!
-    version="2.7.2",
+    version="2.7.3",
     description="Provide design-by-contract with informative violation messages.",
     long_description=long_description,
     url="https://github.com/Parquery/icontract",


### PR DESCRIPTION
* Treat ``__setstate__`` as constructor (#311)

This is a patch release so that we can enable unpickling of class instances where some of the attributes are not pickled and only restored in ``__setstate__``.